### PR TITLE
Serve up inline PDFs as with Cache-Control: public.

### DIFF
--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleHandler.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleHandler.java
@@ -66,6 +66,11 @@ public class ScrambleHandler extends SafeHttpServlet {
                 ScrambleRequest[] scrambleRequests = ScrambleRequest.parseScrambleRequests(query, seed);
                 ByteArrayOutputStream totalPdfOutput = ScrambleRequest.requestsToPdf(globalTitle, generationDate, scrambleRequests, null);
                 response.setHeader("Content-Disposition", "inline");
+
+                // Workaround for Chrome bug with saving PDFs:
+                //  https://bugs.chromium.org/p/chromium/issues/detail?id=69677#c35
+                response.setHeader("Cache-Control", "public");
+
                 sendBytes(request, response, totalPdfOutput, "application/pdf");
             } else if(ext.equals("zip")) {
                 ScrambleRequest[] scrambleRequests = ScrambleRequest.parseScrambleRequests(query, seed);

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleViewHandler.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleViewHandler.java
@@ -236,6 +236,11 @@ public class ScrambleViewHandler extends SafeHttpServlet {
                 ByteArrayOutputStream totalPdfOutput = ScrambleRequest
                         .requestsToPdf(globalTitle, generationDate, scrambleRequests, password);
                 response.setHeader("Content-Disposition", "inline");
+
+                // Workaround for Chrome bug with saving PDFs:
+                //  https://bugs.chromium.org/p/chromium/issues/detail?id=69677#c35
+                response.setHeader("Cache-Control", "public");
+
                 sendBytes(request, response, totalPdfOutput, "application/pdf");
             } else if (extension.equals("zip")) {
                 ByteArrayOutputStream zipOutput = ScrambleRequest


### PR DESCRIPTION
This fixes #225.