### PR TITLE
Duplicate rounds and scrambles Fixes #229

### DIFF
--- a/scrambler-interface/WebContent/scrambler-interface/css/ui.css
+++ b/scrambler-interface/WebContent/scrambler-interface/css/ui.css
@@ -209,11 +209,6 @@ h1 {
   width: 10em;
 }
 
-#events_rounds_interface #rounds_table td.round_remove button {
-  height: 100%;
-  width: 3em;
-}
-
 #events_rounds_interface #rounds_table td input.num_groups {
   width: 3em;
 }

--- a/scrambler-interface/WebContent/scrambler-interface/js/ui.js
+++ b/scrambler-interface/WebContent/scrambler-interface/js/ui.js
@@ -872,13 +872,6 @@ var mark2 = {};
             return count;
         };
 
-        var removeRound = function(eventID, scrambleID) {
-            roundsTbody.removeChild(document.getElementById(scrambleID));
-            document.getElementById("event_amount_value_" + eventID).value = numCurrentRounds(eventID);
-
-            updateHash();
-        };
-
         var removeLastRound = function(eventID) {
             var rounds = getRounds(true);
             var lastRoundOfEvent = null;
@@ -983,11 +976,6 @@ var mark2 = {};
                     { type: "number", value: numCopies, min: 1 }
                     );
             numCopiesInput.classList.add("num_copies");
-
-            var removeTD = mark2.dom.appendElement(newEventTR, "td");
-            removeTD.classList.add("round_remove");
-            var removeButton = mark2.dom.appendElement(removeTD, "button", {}, "X");
-            removeButton.addEventListener("click", removeRound.bind(null, eventID, newEventTR_ID), false);
 
             numSolvesInput.addEventListener("change", updateHash, false);
             numExtraSolvesInput.addEventListener("change", updateHash, false);
@@ -1249,9 +1237,6 @@ var mark2 = {};
             td = document.createElement('td');
             tr.appendChild(td);
             td.appendChild(document.createTextNode('# Copies'));
-            td = document.createElement('td');
-            tr.appendChild(td);
-            td.appendChild(document.createTextNode('Remove'));
 
             roundsTbody = document.createElement('tbody');
             roundsTable.appendChild(roundsTbody);


### PR DESCRIPTION
Simple solution for duplicate #229 and scrambles: instead of removing the round that the user clicked, remove last round. This can be done with the removeLastRound function.

Line 990
changed from
`removeButton.addEventListener("click", removeRound.bind(null, eventID, newEventTR_ID), false);`

to

`removeButton.addEventListener("click", removeLastRound.bind(null, eventID), false);`

Function removeRound deleted, since it's not used anymore.