### PR TITLE
Added a glaring warning about clicking the scramble button twice.

### DIFF
--- a/scrambler-interface/WebContent/scrambler-interface/css/ui.css
+++ b/scrambler-interface/WebContent/scrambler-interface/css/ui.css
@@ -92,6 +92,10 @@ h1 {
   margin-top: 15px;
 }
 
+.scrambleButton.clicked {
+  background-color: red;
+}
+
 #top_interface #helpLinkDiv {
   position: absolute;
   right: 30px;

--- a/scrambler-interface/WebContent/scrambler-interface/js/ui.js
+++ b/scrambler-interface/WebContent/scrambler-interface/js/ui.js
@@ -689,7 +689,7 @@ var mark2 = {};
                     (generatedScrambleCountByPuzzle[sheet.puzzle] || 0) +
                     additionalScramblesCount
                 );
-                        
+
             }
             return generatedScrambleCountByPuzzle;
         }
@@ -1313,7 +1313,12 @@ var mark2 = {};
 
             competitionNameInput.addEventListener('change', updateHash, false);
 
-            scrambleButton.addEventListener('click', callbacks.showScrambles, false);
+            scrambleButton.addEventListener('click', function(e) {
+                mark2.dom.emptyElement(scrambleButton);
+                scrambleButton.appendChild(document.createTextNode("Scramble! (Note: You've already generated scrambles. If you click this button again, the generated scrambles will be the same as the ones you already generated. If you want to generate completely new scrambles, refresh the page (you will not lose your events and rounds).)"));
+                scrambleButton.classList.add('clicked');
+                callbacks.showScrambles(e);
+            }, false);
 
             initializeEventsTable();
 


### PR DESCRIPTION
Some people don't realize that TNoodle generates scrambles in memory, and that confusingly enough, clicking "Scramble!" multiple times doesn't actually generate new scrambles. I've implemented an obnoxious message to teach people how this works. I'm definitely open to suggestions for improving this.

## Before clicking "Scramble!"

![2017-10-31_13 00 28_1201x928_breq](https://user-images.githubusercontent.com/277474/32246276-b520621c-be3b-11e7-9623-2bb517c8b5ca.png)

## After clicking "Scramble!"

![2017-10-31_13 00 35_1194x927_breq](https://user-images.githubusercontent.com/277474/32246294-c42918bc-be3b-11e7-995f-14de2b382e12.png)
