### PR TITLE
Update FMC sheet moves.

### DIFF
--- a/webscrambles/src/i18n/en.yml
+++ b/webscrambles/src/i18n/en.yml
@@ -10,16 +10,16 @@ en:
         graded: Graded by
         result: Result
 
-        rule1: Notate your solution by writing one move per bar.
-        rule2: To delete moves, clearly erase or blacken them.
-        rule3: Face moves F, B, R, L, U, and D are clockwise.
-        rule4: Rotations x, y, and z follow R, U, and F.
-        rule5: "' inverts a move; 2 doubles a move. (e.g.: U', U2)"
-        rule6: "w makes a face move into two layers. (e.g.: Uw)"
-        rule7: "A [lowercase] move is a cube rotation. (e.g.: [u])"
-        rule8: You have 1 hour to find a solution.
-        rule9: Your solution length will be counted in OBTM.
-        rule10: Your solution must be at most %s moves, including rotations.
-        rule11: Your solution must not be directly derived from any part of the scrambling algorithm.
+        rule1: You have 60 minutes to find and write a solution.
+        rule2: Write 1 move per bar. To delete a move, clearly blacken it.
+        rule3: Your solution must not be directly derived from any part of the scrambling algorithm.
+        rule4: Your solution must be at most %s moves, including rotations.
+        rule5: Your result will be counted in OBTM.
+        rule6: "Only use notation from Article 12 of the WCA Regulations. If you are uncertain, use only the exact moves listed here:"
+        faceMoves: Face Moves
+        rotations: Rotations
+        clockwise: "Clockwise"
+        counterClockwise: "Counter-clockwise"
+        double: "Double"
 
         scrambleOnSeparateSheet: Please see separate sheet for scrambles.

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
@@ -648,28 +648,31 @@ class ScrambleRequest {
             offsetTop += fontSize + marginBottom;
         }
 
-        int MAGIC_NUMBER = 40; // kill me now
+        int MAGIC_NUMBER = 30; // kill me now
 
         fontSize = 25;
         rect = new Rectangle(left+(competitorInfoLeft-left)/2, top-MAGIC_NUMBER, right-competitorInfoLeft, 100);
         fitAndShowText(cb, translate("fmc.event", locale), bf, rect, fontSize, PdfContentByte.ALIGN_CENTER);
 
         ArrayList<String> rulesList = new ArrayList<String>();
-        rulesList.add("- "+translate("fmc.rule1", locale));
-        rulesList.add("- "+translate("fmc.rule2", locale));
-        rulesList.add("- "+translate("fmc.rule3", locale));
-        rulesList.add("- "+translate("fmc.rule4", locale));
-        rulesList.add("- "+translate("fmc.rule5", locale));
-        rulesList.add("- "+translate("fmc.rule6", locale));
-        rulesList.add("- "+translate("fmc.rule7", locale));
-        rulesList.add("- "+translate("fmc.rule8", locale));
-        rulesList.add("- "+translate("fmc.rule9", locale));
+        rulesList.add("• "+translate("fmc.rule1", locale));
+        rulesList.add("• "+translate("fmc.rule2", locale));
+        rulesList.add("• "+translate("fmc.rule3", locale));
         int maxMoves = WCA_MAX_MOVES_FMC;
-        rulesList.add("- "+String.format(translate("fmc.rule10", locale), maxMoves));
-        rulesList.add("- "+translate("fmc.rule11", locale));
+        rulesList.add("• "+String.format(translate("fmc.rule4", locale), maxMoves));
+        rulesList.add("• "+translate("fmc.rule5", locale));
+        rulesList.add("• "+translate("fmc.rule6", locale));
+        rulesList.add("  • "+translate("fmc.faceMoves", locale));
+        rulesList.add("    • "+String.format("R     U     F     L     B     D      (%s)", translate("fmc.clockwise", locale)));
+        rulesList.add("    • "+String.format("R'    U'    F'    L'    B'    D'      (%s)", translate("fmc.counterClockwise", locale)));
+        rulesList.add("    • "+String.format("R2   U2   F2   L2   B2   D2    (%s)", translate("fmc.double", locale)));
+        rulesList.add("  • "+translate("fmc.rotations", locale));
+        rulesList.add("    • "+String.format("[r]     [u]     [f]     [l]     [b]     [d]      (%s)", translate("fmc.clockwise", locale)));
+        rulesList.add("    • "+String.format("[r']    [u']    [f']    [l']    [b']    [d']      (%s)", translate("fmc.counterClockwise", locale)));
+        rulesList.add("    • "+String.format("[r2]   [u2]   [f2]   [l2]   [b2]   [d2]    (%s)", translate("fmc.double", locale)));
 
-        int rulesTop = competitorInfoBottom + (withScramble ? 55 : 143);
-        Rectangle rulesRectangle = new Rectangle(left+padding, scrambleBorderTop, competitorInfoLeft-padding, rulesTop);
+        int rulesTop = competitorInfoBottom + (withScramble ? 65 : 153);
+        Rectangle rulesRectangle = new Rectangle(left+padding, scrambleBorderTop+padding*2, competitorInfoLeft-padding, rulesTop);
 
         String rules = String.join("\n", rulesList);
         float leadingMultiplier = 1.5f; // default pdf leading


### PR DESCRIPTION
Formatting/layout is still uneven, and I *really* want to implement a table layout before shipping.

However, I think this is a reasonable middle ground, and already updates all the strings so that we can get translations.

<img width="461" alt="screen shot 2017-12-24 at 19 09 53" src="https://user-images.githubusercontent.com/248078/34331714-147fca00-e8de-11e7-80d8-ffbeabac39aa.png">


The "Fewest Moves" title is given a little less space, so that the text formatting in English doesn't have a lot of awkward space at the bottom.
