### PR TITLE
Implement Rails-style support for variable interpolation when translating.

### DIFF
--- a/webscrambles/src/i18n/en.yml
+++ b/webscrambles/src/i18n/en.yml
@@ -1,8 +1,8 @@
 en:
     fmc:
+        scrambleXofY: Scramble %{scrambleIndex} of %{scrambleCount}
         scramble: Scramble
         round: Round
-        of: of
         attempt: Attempt
         competitor: Competitor
         warning: DO NOT FILL IF YOU ARE THE COMPETITOR.
@@ -13,7 +13,7 @@ en:
         rule1: You have 60 minutes to find and write a solution.
         rule2: Write 1 move per bar. To delete a move, clearly blacken it.
         rule3: Your solution must not be directly derived from any part of the scrambling algorithm.
-        rule4: Your solution must be at most %s moves, including rotations.
+        rule4: Your solution must be at most %{maxMoves} moves, including rotations.
         rule5: Your result will be counted in OBTM.
         rule6: "Only use notation from Article 12 of the WCA Regulations. If you are uncertain, use only the exact moves listed here:"
         faceMoves: Face Moves

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
@@ -592,7 +592,11 @@ class ScrambleRequest {
             offsetTop += fontSize + 2;
 
             rect = new Rectangle(competitorInfoLeft+(right-competitorInfoLeft)/2, top-offsetTop, right-competitorInfoLeft, 100);
-            fitAndShowText(cb, translate("fmc.scramble", locale)+" " + (index+1) + " "+translate("fmc.of", locale)+" "+ scrambleRequest.scrambles.length, bf, rect, fontSize, PdfContentByte.ALIGN_CENTER);
+
+            HashMap<String, String> substitutions = new HashMap<String, String>();
+            substitutions.put("scrambleIndex", ""+(index+1));
+            substitutions.put("scrambleCount", ""+(scrambleRequest.scrambles.length));
+            fitAndShowText(cb, translate("fmc.scrambleXofY", locale, substitutions), bf, rect, fontSize, PdfContentByte.ALIGN_CENTER);
         }
 
         offsetTop += fontSize + (int) (marginBottom*(withScramble ? 1 : 2.8));
@@ -659,7 +663,11 @@ class ScrambleRequest {
         rulesList.add("• "+translate("fmc.rule2", locale));
         rulesList.add("• "+translate("fmc.rule3", locale));
         int maxMoves = WCA_MAX_MOVES_FMC;
-        rulesList.add("• "+String.format(translate("fmc.rule4", locale), maxMoves));
+
+        HashMap<String, String> substitutions = new HashMap<String, String>();
+        substitutions.put("maxMoves", ""+maxMoves);
+        rulesList.add("• "+translate("fmc.rule4", locale, substitutions));
+
         rulesList.add("• "+translate("fmc.rule5", locale));
         rulesList.add("• "+translate("fmc.rule6", locale));
         rulesList.add("  • "+translate("fmc.faceMoves", locale));

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/Translate.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/Translate.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Set;
 
 import net.gnehzr.tnoodle.utils.EnvGetter;
@@ -95,14 +97,42 @@ public class Translate {
     }
 
     public static String translate(String key, Locale locale) {
-        // First, attempt to translate in the given locale.
+        return translate(key, locale, new HashMap<String, String>());
+    }
+
+    public static String translate(String key, Locale locale, Map<String, String> substitutions) {
+        // Attempt to translate in the given locale.
         String translation = translate(key, locale, false);
-        if(translation != null) {
-            return translation;
-        } else {
-            // If we couldn't find a translation in the given locale, fallback to the base locale.
-            return translate(key, BASE_LOCALE, true);
+        if(translation == null) {
+            // If we couldn't find a translation in the given locale, fall back to the base locale.
+            translation = translate(key, BASE_LOCALE, true);
         }
+
+        translation = interpolate(translation, substitutions);
+        return translation;
+    }
+
+    // Interpolate translation keys in the same way Ruby on Rails does.
+    // See: http://guides.rubyonrails.org/i18n.html#passing-variables-to-translations
+    private static String interpolate(String interpolateMe, Map<String, String> substitutions) {
+        // Copy the given Map, as we're going to mutate it later on.
+        substitutions = new HashMap<String, String>(substitutions);
+
+        // Now interpolate variables in the input string.
+        //
+        // Find anything that looks like %{...}, unless the percent sign is escaped as in %%{...}
+        Pattern templatePattern = Pattern.compile("(?<!%)%\\{([^}]+)\\}");
+        Matcher matcher = templatePattern.matcher(interpolateMe);
+        StringBuffer sb = new StringBuffer();
+        while(matcher.find()) {
+            String key = matcher.group(1);
+            String replacement = substitutions.remove(key);
+            azzert(replacement != null, String.format("Substitution for key: %s not found", key));
+            matcher.appendReplacement(sb, replacement);
+        }
+        matcher.appendTail(sb);
+        azzert(substitutions.size() == 0, String.format("Unused substitution values: %s", substitutions.keySet()));
+        return sb.toString();
     }
 
     // Copied from https://gist.github.com/aslakhellesoy/3858814


### PR DESCRIPTION
This fixes #263.
This should also address an issue with Vietnamese that @leduyquang753
ran into, see his description here:
https://github.com/thewca/tnoodle/pull/278#issuecomment-355727816

Unfortunately, this does trigger a bunch of outdated translations:

<details>

```
✗ da:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ es:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ et:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ fi:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ fr:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ hu:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ ja:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ ko:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ nb:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ pl:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ pt:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ pt-BR:	22 total
	• 1 missing:
		fmc > scrambleXofY
	• 20 outdated:
		fmc > scramble
		fmc > round
		fmc > attempt
		fmc > competitor
		fmc > warning
		fmc > event
		fmc > graded
		fmc > result
		fmc > rule1
		fmc > rule2
		fmc > rule3
		fmc > rule4
		fmc > rule5
		fmc > rule6
		fmc > faceMoves
		fmc > rotations
		fmc > clockwise
		fmc > counterClockwise
		fmc > double
		fmc > scrambleOnSeparateSheet
	• 1 unused:
		fmc > of
✗ ru:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ sl:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
✗ zh-CN:	27 total
	• 6 missing:
		fmc > scrambleXofY
		fmc > faceMoves
		fmc > rotations
		fmc > clockwise
		fmc > counterClockwise
		fmc > double
	• 15 outdated:
		fmc > scramble
		fmc > round
		fmc > attempt
		fmc > competitor
		fmc > warning
		fmc > event
		fmc > graded
		fmc > result
		fmc > rule1
		fmc > rule2
		fmc > rule3
		fmc > rule4
		fmc > rule5
		fmc > rule6
		fmc > scrambleOnSeparateSheet
	• 6 unused:
		fmc > of
		fmc > rule7
		fmc > rule8
		fmc > rule9
		fmc > rule10
		fmc > rule11
✗ zh-TW:	3 total
	• 1 missing:
		fmc > scrambleXofY
	• 1 outdated:
		fmc > rule4
	• 1 unused:
		fmc > of
```

</details>