### PR TITLE
Add support for 333mbf to new UI

### DIFF
--- a/tnoodle-ui/src/ManageCompetition.js
+++ b/tnoodle-ui/src/ManageCompetition.js
@@ -93,7 +93,8 @@ class ManageCompetition extends Component {
       generationArea = <button
           className="btn btn-block btn-lg btn-primary"
           onClick={() => {
-            dispatch(actions.generateMissingScrambles(roundsWithMissingGroups));
+            let puzzlesPerMbfAttempt = 28;//<<<
+            dispatch(actions.generateMissingScrambles(roundsWithMissingGroups, puzzlesPerMbfAttempt));
             this.setState({ hasStartedGeneratingScrambles: true });
           }}
         >

--- a/tnoodle-ui/src/SelectCompetition.js
+++ b/tnoodle-ui/src/SelectCompetition.js
@@ -33,7 +33,8 @@ export default connect(
             <div className="list-group">
               {competitions.map(competition => {
                 return (
-                  <PreserveSearchLink key={competition.id} to={`/competitions/${competition.id}`} className="list-group-item list-group-item-action">{competition.id}</PreserveSearchLink>
+                  <PreserveSearchLink key={competition.id} to={`/competitions/${competition.id}`} className="list-group-item list-group-item-action">{competition.name}</PreserveSearchLink>
+
                 );
               })}
             </div>

--- a/tnoodle-ui/src/WcaCompetitionJson.js
+++ b/tnoodle-ui/src/WcaCompetitionJson.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import deepcopy from 'deepcopy';
 
-export function formatToScrambleCount(format) {
+export function formatToScrambleCount(format, eventId) {
   // From https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/db/seeds/formats.seeds.rb
   let scrambleCount = {
     "1": 1,
@@ -15,7 +15,8 @@ export function formatToScrambleCount(format) {
     throw new Error(`Unrecognized format: ${format}`);
   }
 
-  return { scrambleCount, extraScrambleCount: 2 };
+  let extraScrambleCount = (eventId !== "333mbf" ? 2 : 0);
+  return { scrambleCount, extraScrambleCount };
 }
 
 const nextLetterInAlphabet = letter => {
@@ -144,7 +145,7 @@ export function checkScrambles(wcaCompetitionJson) {
         return;
       }
 
-      let { scrambleCount: requiredScrambleCountPerGroup, extraScrambleCount: requiredExtraScrambleCountPerGroup } = formatToScrambleCount(wcaRound.format);
+      let { scrambleCount: requiredScrambleCountPerGroup, extraScrambleCount: requiredExtraScrambleCountPerGroup } = formatToScrambleCount(wcaRound.format, eventId);
       checked.scramblesNeededCount += (requiredScrambleCountPerGroup + requiredExtraScrambleCountPerGroup) * wcaRound.scrambleGroupCount;
 
       let roundScramblesPerfect = true;

--- a/tnoodle-ui/src/WcaCompetitionJson.test.js
+++ b/tnoodle-ui/src/WcaCompetitionJson.test.js
@@ -69,6 +69,16 @@ it('checkScrambles finds missing scrambles', () => {
           },
         ],
       },
+      {
+        id: "333mbf",
+        rounds: [
+          {
+            id: "333mbf-r1",
+            format: "2",
+            groups: null,
+          },
+        ],
+      },
     ],
   };
 
@@ -76,7 +86,7 @@ it('checkScrambles finds missing scrambles', () => {
 
   expect(checkedScrambles).toEqual({
     currentScrambleCount: 19,
-    scramblesNeededCount: 6*(5+2),
+    scramblesNeededCount: 6*(5+2) + 2,
     finishedRounds: [
       {
         id: "333-r3",
@@ -104,6 +114,11 @@ it('checkScrambles finds missing scrambles', () => {
       },
       {
         id: "222-r2",
+        groupCount: 0,
+        scrambleGroupCount: 1,
+      },
+      {
+        id: "333mbf-r1",
         groupCount: 0,
         scrambleGroupCount: 1,
       },

--- a/tnoodle-ui/src/actions.js
+++ b/tnoodle-ui/src/actions.js
@@ -166,7 +166,7 @@ export function downloadScrambles({ pdf, password }) {
     let competitionJson = state.competitionJson;
 
     let request = competitionJsonToTNoodleScrambleRequest(competitionJson);
-    let title = `Scrambles for ${competitionJson.id}`;
+    let title = `Scrambles for ${competitionJson.name}`;
     if(pdf) {
       return scrambler.showPdf(title, request, password, "_blank");
     } else {

--- a/tnoodle-ui/src/actions.test.js
+++ b/tnoodle-ui/src/actions.test.js
@@ -22,32 +22,58 @@ describe('async actions', () => {
       ;
     });
 
-    let rounds = [
-      {
-        id: "333-r1",
-        format: "a",
-        groups: [],
-      },
-      {
-        id: "333-r2",
-        format: "a",
-        groups: [
-          {
-            group: "a",
-            scrambles: [ "1", "2", "3" ],
-          },
-        ],
-      },
-    ];
+    let twentyMbfScrambles1 = [...Array(20).keys()].map(i => `Attempt-1.${i}`);
+    let twentyMbfScrambles2 = [...Array(20).keys()].map(i => `Attempt-2.${i}`);
+    xhrMock.get("http://localhost:2014/scramble/.json?=333ni*40&showIndices=1", (req, res) => {
+      return res
+        .status(200)
+        .header('Content-Type', 'application/json')
+        .body(JSON.stringify([{ scrambles: twentyMbfScrambles1.concat(twentyMbfScrambles2) }]))
+      ;
+    });
+
+    // Catch any unexpected API calls.
+    xhrMock.get(new RegExp("http://localhost:2014/*"), (req, res) => {
+      console.error(`Not mocked: ${req.method()} ${req.url()}`);
+      return res.status(500);
+    });
+
     let wcaCompetitionJson = {
       events: [
         {
           id: "333",
-          rounds,
+          rounds: [
+            {
+              id: "333-r1",
+              format: "a",
+              groups: [],
+            },
+            {
+              id: "333-r2",
+              format: "a",
+              groups: [
+                {
+                  group: "a",
+                  scrambles: [ "1", "2", "3" ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: "333mbf",
+          rounds: [
+            {
+              id: "333mbf-r1",
+              format: "2",
+              groups: [],
+            },
+          ],
         },
       ],
     };
 
+    let rounds = [].concat(...wcaCompetitionJson.events.map(wcifEvent => wcifEvent.rounds));
     const expectedActions = [
       {
         type: 'GENERATE_MISSING_SCRAMBLES',
@@ -60,10 +86,21 @@ describe('async actions', () => {
         scrambles: [ "S1", "S2", "S3", "S4", "S5" ],
         extraScrambles: [ "E1", "E2" ],
       },
+      {
+        type: 'GROUP_FOR_ROUND',
+        activityCode: "333mbf-r1",
+        groupName: "A",
+        scrambles: [
+          twentyMbfScrambles1.join("\n"),
+          twentyMbfScrambles2.join("\n"),
+        ],
+        extraScrambles: [],
+      },
     ];
     const store = mockStore({ competitionJson: normalizeCompetitionJson(wcaCompetitionJson) });
 
-    store.dispatch(actions.generateMissingScrambles(wcaCompetitionJson.events[0].rounds));
+    let puzzlesPerMbfAttempt = 20;
+    store.dispatch(actions.generateMissingScrambles(rounds, puzzlesPerMbfAttempt));
 
     // This setTimeout is a quick hack to wait for our async thunks to run.
     return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {

--- a/tnoodle-ui/src/actions.test.js
+++ b/tnoodle-ui/src/actions.test.js
@@ -77,7 +77,6 @@ describe('async actions', () => {
     const expectedActions = [
       {
         type: 'GENERATE_MISSING_SCRAMBLES',
-        rounds,
       },
       {
         type: 'GROUP_FOR_ROUND',
@@ -97,10 +96,12 @@ describe('async actions', () => {
         extraScrambles: [],
       },
     ];
-    const store = mockStore({ competitionJson: normalizeCompetitionJson(wcaCompetitionJson) });
+    const store = mockStore({
+      competitionJson: normalizeCompetitionJson(wcaCompetitionJson),
+      puzzlesPer333mbfAttempt: 20,
+    });
 
-    let puzzlesPerMbfAttempt = 20;
-    store.dispatch(actions.generateMissingScrambles(rounds, puzzlesPerMbfAttempt));
+    store.dispatch(actions.generateMissingScrambles());
 
     // This setTimeout is a quick hack to wait for our async thunks to run.
     return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {

--- a/tnoodle-ui/src/reducers.js
+++ b/tnoodle-ui/src/reducers.js
@@ -29,14 +29,50 @@ export const competitionJson = function(state=null, action) {
       extraScrambles: action.extraScrambles,
     });
     return normalizeCompetitionJson(competitionJson);
+  } else if(action.type === "CLEAR_SCRAMBLES") {
+    let competitionJson = deepcopy(state);
+    competitionJson.events.forEach(event => {
+      event.rounds.forEach(round => {
+        round.groups = [];
+      });
+    });
+    return normalizeCompetitionJson(competitionJson);
   } else {
     return state;
   }
 };
 
+export const isGeneratingScrambles = function(state=false, action) {
+  if(action.type === "GENERATE_MISSING_SCRAMBLES") {
+    return true;
+  } else if(action.type === "DONE_GENERATING_SCRAMBLES") {
+    return false;
+  } else {
+    return state;
+  }
+}
+
+export const isGeneratingZip = function(state=false, action) {
+  if(action.type === "BEGIN_FETCH_SCRAMBLE_ZIP") {
+    return true;
+  } else if(action.type === "SCRAMBLE_ZIP_FETCHED") {
+    return false;
+  } else {
+    return state;
+  }
+}
+
 export const loadCompetitionJsonError = function(state=null, action) {
   if(action.type === "FETCH_COMPETITION_JSON" && action.status === "error") {
     return action.error;
+  } else {
+    return state;
+  }
+}
+
+export const puzzlesPer333mbfAttempt = function(state=28, action) {
+  if(action.type === "SET_PUZZLES_PER_333MBF_ATTEMPT") {
+    return action.puzzlesPer333mbfAttempt;
   } else {
     return state;
   }

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
@@ -250,7 +250,7 @@ class ScrambleRequest {
         // list of 333ni scrambles.
         // If we detect that we're dealing with 333mbf, then we will generate 1 sheet per attempt,
         // rather than 1 sheet per round (as we do with every other event).
-        boolean is333mbf = scrambleRequest.scrambler.getShortName().equals("333ni") && scrambleRequest.scrambles[0].indexOf('\n') > 0;
+        boolean is333mbf = scrambleRequest.event.equals("333mbf");
         if(is333mbf) {
             Document doc = new Document();
             ByteArrayOutputStream totalPdfOutput = new ByteArrayOutputStream();
@@ -267,6 +267,7 @@ class ScrambleRequest {
                 attemptRequest.copies = scrambleRequest.copies;
                 attemptRequest.title = scrambleRequest.title + " Attempt " + nthAttempt;
                 attemptRequest.fmc = false;
+                attemptRequest.event = "333bf";
                 attemptRequest.colorScheme = scrambleRequest.colorScheme;
 
                 PdfReader pdfReader = createPdf(globalTitle, creationDate, attemptRequest, locale);
@@ -664,7 +665,7 @@ class ScrambleRequest {
 
             offsetTop += fontSize + marginBottom;
         }
-        
+
         int fmcMargin = 10;
 
 
@@ -676,7 +677,7 @@ class ScrambleRequest {
         int cellHeight = tableHeight/tableLines;
         int columns = 7;
         int firstColumnWidth = tableWidth-(columns-1)*cellWidth;
-        
+
         int movesFontSize = 10;
         Font movesFont = new Font(bf, movesFontSize);
 
@@ -708,17 +709,17 @@ class ScrambleRequest {
                 movesCell[1][i][j] = "["+moves[j].toLowerCase()+directionModifiers[i]+"]";
             }
         }
-        
+
         Rectangle firstColumnRectangle = new Rectangle(firstColumnWidth, cellHeight);
         float firstColumnFontSize = fitText(new Font(bf), movesType[0], firstColumnRectangle, 10, false, 1f);
-        
+
         for (String item : movesType){
             firstColumnFontSize = Math.min(firstColumnFontSize, fitText(new Font(bf, firstColumnFontSize, Font.BOLD), item, firstColumnRectangle, 10, false, 1f));
         }
         for (String item : direction){
             firstColumnFontSize = Math.min(firstColumnFontSize, fitText(new Font(bf, firstColumnFontSize), item, firstColumnRectangle, 10, false, 1f));
         }
-        
+
         // Center the table
         float maxFirstColumnWidth = 0;
         float maxLastColumnWidth = 0;
@@ -757,14 +758,14 @@ class ScrambleRequest {
                     cell.setHorizontalAlignment(Element.ALIGN_CENTER);
                     cell.setBorder(Rectangle.NO_BORDER);
                     table.addCell(cell);
-                    
+
                     if (k == moves.length-1) {
                         maxLastColumnWidth = Math.max(maxLastColumnWidth, bf.getWidthPoint(movesCell[i][j][k], movesFontSize));
                     }
                 }
             }
         }
-        
+
         // Position the table
         table.writeSelectedRows(0, -1, left+fmcMargin+(cellWidth-maxLastColumnWidth)/2-(firstColumnWidth-maxFirstColumnWidth)/2, scrambleBorderTop+tableHeight+fmcMargin, cb);
 
@@ -790,14 +791,14 @@ class ScrambleRequest {
         rulesList.add("• "+translate("fmc.rule6", locale));
 
         int rulesTop = competitorInfoBottom + (withScramble ? 65 : 153);
-        
+
         Rectangle rulesRectangle = new Rectangle(left+fmcMargin, scrambleBorderTop+tableHeight+fmcMargin, competitorInfoLeft-fmcMargin, rulesTop+fmcMargin);
         String rules = String.join("\n", rulesList);
         fitAndShowTextNew(cb, rules, bf, rulesRectangle, 15, Element.ALIGN_JUSTIFIED, 1.5f);
 
         doc.newPage();
     }
-    
+
     private static void fitAndShowTextNew(PdfContentByte cb, String text, BaseFont bf, Rectangle rect, float maxFontSize, int align, float leading) throws DocumentException {
         // We create a temp pdf and check if the text fit in a rectangle there.
         // If it's ok, we add the text to original pdf.
@@ -825,7 +826,7 @@ class ScrambleRequest {
                 ct.go();
                 break;
             }
-            
+
             maxFontSize -= 0.1;
         } while(true);
     }


### PR DESCRIPTION
The new UI now detects if a competition is running 333mbf, and if so, it asks the user how many scrambles they want per attempt of 333mbf (it defaults to 28):

![image](https://user-images.githubusercontent.com/277474/35487299-daca86ee-042e-11e8-93f8-9675cc356a6e.png)

