### PR TITLE
Fix silly mistake in round's id

### DIFF
--- a/tnoodle-ui/src/actions.js
+++ b/tnoodle-ui/src/actions.js
@@ -119,7 +119,7 @@ function competitionJsonToTNoodleScrambleRequest(competitionJson) {
           fmc: isFmc(event.id),
 
           event: event.id,
-          round: round.roundNumber,
+          round: roundNumber,
           group: group.group,
         };
         scrambleRequest.push(request);


### PR DESCRIPTION
`round.roundNumber` is undefined, leading to all round ids being "0" in the scrambles json file.

See this extract from TMU 2018's scrambles json:
>{"scrambles":["L' F2 U2 L2 B2 R' U2 R D R' U2 B U' B L B2 F' U L2","D' R2 B2 D2 L2 D2 F2 U' R2 B L D' U F2 R D' L D' L' R","U2 B2 R2 U B2 R2 B2 D' U2 L' U2 B D' L B L2 B R F' L","F L2 R2 F2 R2 B' F2 L2 U2 R' U' R2 D L' D U2 B' L2 R U'","F2 R2 B2 D F2 D' R2 D' U2 F L R2 F' L2 B D2 L F R D'"],"extraScrambles":["D2 F2 U2 B2 R' D2 L2 D2 B2 U2 R' F D U' L2 F' D2 L D","R2 D' B2 U2 B2 L2 U L2 F D' B2 D F L' D2 F' U2 L2 R"],"scrambler":"333","copies":1,"title":"3x3x3 Cube Round 1 Group A","fmc":false,"group":"A","event":"333","round":0}

@jfly since I'm very unfamiliar with the code for all that is UI related, could you please check I did not forget to make a similar change somewhere?
I also have no idea how to write a test for this...
