### PR TITLE
Prevent password managers from trying to save this password.

### DIFF
--- a/tnoodle-ui/src/ManageCompetition.js
+++ b/tnoodle-ui/src/ManageCompetition.js
@@ -143,6 +143,7 @@ class ManageCompetition extends Component {
               <div className="input-group input-group-lg">
                 <input
                   type={showScramblePassword ? "text" : "password"}
+                  autoComplete="new-password"
                   disabled={isGeneratingScrambles || isGeneratingZip}
                   className="form-control"
                   placeholder="Password"


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields and https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands