### PR TITLE
scrambleGroupCount has been renamed to scrambleSetCount in the WCIF.

### DIFF
--- a/tnoodle-ui/src/WcaCompetitionJson.js
+++ b/tnoodle-ui/src/WcaCompetitionJson.js
@@ -108,8 +108,11 @@ export function normalizeCompetitionJson(competitionJson) {
   competitionJson.events.forEach(event => {
     event.rounds.forEach(round => {
       round.groups = round.groups || [];
-      if(!round.scrambleGroupCount) {
-        round.scrambleGroupCount = round.groups.length || 1;
+      if(!round.scrambleSetCount) {
+        // We look at scrambleGroupCount here for backwards compatibility.
+        // The attribute has been renamed to scrambleSetCount, but the WCA website has not
+        // yet been updated accordingly.
+        round.scrambleSetCount = round.scrambleGroupCount || round.groups.length || 1;
       }
       round.groups.forEach(group => {
         group.scrambles = group.scrambles || [];
@@ -146,14 +149,14 @@ export function checkScrambles(wcaCompetitionJson) {
       }
 
       let { scrambleCount: requiredScrambleCountPerGroup, extraScrambleCount: requiredExtraScrambleCountPerGroup } = formatToScrambleCount(wcaRound.format, eventId);
-      checked.scramblesNeededCount += (requiredScrambleCountPerGroup + requiredExtraScrambleCountPerGroup) * wcaRound.scrambleGroupCount;
+      checked.scramblesNeededCount += (requiredScrambleCountPerGroup + requiredExtraScrambleCountPerGroup) * wcaRound.scrambleSetCount;
 
       let roundScramblesPerfect = true;
-      if(wcaRound.groups.length < wcaRound.scrambleGroupCount) {
+      if(wcaRound.groups.length < wcaRound.scrambleSetCount) {
         checked.roundsWithMissingGroups.push({
           id: buildActivityCode({ eventId, roundNumber }),
           groupCount: wcaRound.groups.length,
-          scrambleGroupCount: wcaRound.scrambleGroupCount,
+          scrambleSetCount: wcaRound.scrambleSetCount,
         });
         roundScramblesPerfect = false;
       }
@@ -204,7 +207,7 @@ export function checkScrambles(wcaCompetitionJson) {
         checked.finishedRounds.push({
           id: buildActivityCode({ eventId, roundNumber }),
           groupCount: wcaRound.groups.length,
-          scrambleGroupCount: wcaRound.scrambleGroupCount,
+          scrambleSetCount: wcaRound.scrambleSetCount,
         });
       }
     });

--- a/tnoodle-ui/src/WcaCompetitionJson.test.js
+++ b/tnoodle-ui/src/WcaCompetitionJson.test.js
@@ -43,7 +43,7 @@ it('checkScrambles finds missing scrambles', () => {
           {
             id: "333-r4",
             format: "a",
-            scrambleGroupCount: 2,
+            scrambleSetCount: 2,
             groups: [
               {
                 group: "A",
@@ -91,7 +91,7 @@ it('checkScrambles finds missing scrambles', () => {
       {
         id: "333-r3",
         groupCount: 1,
-        scrambleGroupCount: 1,
+        scrambleSetCount: 1,
       },
     ],
     groupsWithWrongNumberOfScrambles: [
@@ -105,22 +105,22 @@ it('checkScrambles finds missing scrambles', () => {
       {
         id: "333-r4",
         groupCount: 1,
-        scrambleGroupCount: 2,
+        scrambleSetCount: 2,
       },
       {
         id: "222-r1",
         groupCount: 0,
-        scrambleGroupCount: 1,
+        scrambleSetCount: 1,
       },
       {
         id: "222-r2",
         groupCount: 0,
-        scrambleGroupCount: 1,
+        scrambleSetCount: 1,
       },
       {
         id: "333mbf-r1",
         groupCount: 0,
-        scrambleGroupCount: 1,
+        scrambleSetCount: 1,
       },
     ],
     warnings: [

--- a/tnoodle-ui/src/actions.js
+++ b/tnoodle-ui/src/actions.js
@@ -36,10 +36,10 @@ export function generateMissingScrambles(rounds) {
       let activityCode = round.id;
       let { eventId } = parseActivityCode(activityCode);
       let wcaRound = getActivity(getState().competitionJson, activityCode);
-      let groupsToGenerateCount = wcaRound.scrambleGroupCount - wcaRound.groups.length;
+      let setsToGenerateCount = wcaRound.scrambleSetCount - wcaRound.groups.length;
       let usedGroupNames = wcaRound.groups.map(wcaGroup => wcaGroup.group);
       let namesOfGroupsToGenerate = [];
-      for(let i = 0; i < groupsToGenerateCount; i++) {
+      for(let i = 0; i < setsToGenerateCount; i++) {
         namesOfGroupsToGenerate.push(getNextAvailableGroupName(usedGroupNames.concat(namesOfGroupsToGenerate)));
       }
       let { scrambleCount, extraScrambleCount } = formatToScrambleCount(wcaRound.format, eventId);


### PR DESCRIPTION
If scrambleSetCount is not defined in the WCIF, then we will look at
scrambleGroupCount. This allows us to be compatible with the WCA website
as it changes to use scrambleSetCount.