### PR TITLE
Force users to input number for mbld

### DIFF
--- a/tnoodle-ui/README.md
+++ b/tnoodle-ui/README.md
@@ -12,7 +12,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## Connecting to staging WCA server
 
-Set the `staging` url parameter. For example, try going to http://localhost:3001/staging=true
+Set the `staging` url parameter. For example, try going to http://localhost:3001?staging=true
 
 ## Connecting to a development WCA server
 

--- a/tnoodle-ui/src/ManageCompetition.js
+++ b/tnoodle-ui/src/ManageCompetition.js
@@ -21,6 +21,37 @@ class ManageCompetition extends Component {
     };
   }
 
+  _renderMbldArea() {
+    let {
+      puzzlesPer333mbfAttempt,
+      isGeneratingScrambles,
+      isGeneratingZip,
+      dispatch,
+    } = this.props;
+
+    const suggestedNumberOfPuzzles = 28;
+
+    return <React.Fragment>
+      <p>
+        This competition has {events.byId['333mbf'].name}. How many scrambles do you want for each attempt?
+        {' '}<button className="btn btn-sm btn-primary" onClick={e => {
+          dispatch(actions.setPuzzlesPer333mbfAttempt(suggestedNumberOfPuzzles));
+        }}>May I suggest {suggestedNumberOfPuzzles}?</button>
+      </p>
+      <p>
+        <input
+          type="number"
+          placeholder="How many puzzles do you expect people to attempt?"
+          disabled={isGeneratingScrambles || isGeneratingZip}
+          className="form-control"
+          value={puzzlesPer333mbfAttempt}
+          ref={input => this.puzzlesPerMbfAttemptInput = input}
+          onChange={e => dispatch(actions.setPuzzlesPer333mbfAttempt(e.target.value))}
+        />
+      </p>
+    </React.Fragment>;
+  }
+
   render() {
     let {
       competitionJson,
@@ -74,6 +105,7 @@ class ManageCompetition extends Component {
 
     let { showScramblePassword } = this.state;
     let progress = currentScrambleCount / scramblesNeededCount;
+    let hasMbld = competitionJson.events.find(event => event.id === '333mbf');
 
     let generationArea;
     if(scrambleZip) {
@@ -98,8 +130,15 @@ class ManageCompetition extends Component {
         </div>
       </div>;
     } else {
+      let disabled, title;
+      if(hasMbld && !puzzlesPer333mbfAttempt) {
+        disabled = true;
+        title = `You must set a number of puzzles to generate scrambles for ${events.byId['333mbf'].name}.`;
+      }
       generationArea = <button
           className="btn btn-block btn-lg btn-primary"
+          disabled={disabled}
+          title={title}
           onClick={() => {
             dispatch(actions.generateMissingScrambles());
           }}
@@ -123,19 +162,7 @@ class ManageCompetition extends Component {
           You can view and change the rounds over on <a href={toWcaUrl(`/competitions/${competitionJson.id}/events/edit`)} target="_blank">the WCA website</a>. <strong>Refresh this page after making any changes on the WCA website.</strong>
         </p>
 
-        {competitionJson.events.map(event => event.id).includes('333mbf') && (
-          <p>
-            This competition has {events.byId['333mbf'].name}. How many scrambles do you want for each attempt?
-            <input
-              type="number"
-              disabled={isGeneratingScrambles || isGeneratingZip}
-              className="form-control"
-              value={puzzlesPer333mbfAttempt}
-              ref={input => this.puzzlesPerMbfAttemptInput = input}
-              onChange={e => dispatch(actions.setPuzzlesPer333mbfAttempt(e.target.value))}
-            />
-          </p>
-        )}
+        {hasMbld && this._renderMbldArea()}
 
         <div className="row scramble-form">
           <div className="col-6">

--- a/tnoodle-ui/src/WcaApi.js
+++ b/tnoodle-ui/src/WcaApi.js
@@ -61,6 +61,68 @@ export function getUpcomingManageableCompetitions() {
   ).then(response => response.json());
 }
 
+export function getRecords() {
+  return wcaApiFetch(`/records`).then(response => response.json());
+}
+
+
+// Copied from https://github.com/cubing/ccm/blob/master/both/lib/wca.js.
+const DNF_VALUE = -1;
+const DNS_VALUE = -2;
+
+const DNF_SOLVE_TIME = {
+  puzzlesSolvedCount: 0,
+  puzzlesAttemptedCount: 1,
+};
+
+const DNS_SOLVE_TIME = {
+  puzzlesSolvedCount: 0,
+  puzzlesAttemptedCount: 0,
+};
+
+export function valueToSolveTime(wcaValue, eventId) {
+  if(wcaValue === 0) {
+    // A wcaValue of 0 means "nothing happened here"
+    return null;
+  }
+  if(wcaValue === DNF_VALUE) {
+    return DNF_SOLVE_TIME;
+  }
+  if(wcaValue === DNS_VALUE) {
+    return DNS_SOLVE_TIME;
+  }
+
+  if(eventId === '333fm') {
+    var moveCount = wcaValue;
+    return {
+      moveCount: moveCount,
+    };
+  } else if(eventId === '333mbf') {
+    // From https://www.worldcubeassociation.org/results/misc/export.html
+    var difference = 99 - Math.floor(wcaValue / 1e7);
+    wcaValue %= 1e7;
+
+    var timeInSeconds = Math.floor(wcaValue / 1e2);
+    wcaValue %= 1e2;
+
+    var missed = wcaValue;
+    var solved = difference + missed;
+    var attempted = solved + missed;
+
+    return {
+      millis: timeInSeconds*1000,
+      puzzlesSolvedCount: solved,
+      puzzlesAttemptedCount: attempted,
+    };
+  } else {
+    var centiseconds = wcaValue;
+    return {
+      millis: centiseconds*10,
+      decimals: 2,
+    };
+  }
+}
+
 function getHashParameter(name) {
   return parseQueryString(window.location.hash)[name];
 }

--- a/tnoodle-ui/src/actions.js
+++ b/tnoodle-ui/src/actions.js
@@ -15,6 +15,10 @@ export function fetchCompetitionJson(competitionId) {
   return wrapPromiseWithDispatch(WcaApi.getCompetitionJson(competitionId), 'FETCH_COMPETITION_JSON');
 }
 
+export function fetchRecords() {
+  return wrapPromiseWithDispatch(WcaApi.getRecords(), 'FETCH_RECORDS');
+}
+
 export function fetchUpcomingManageableCompetitions() {
   return wrapPromiseWithDispatch(WcaApi.getUpcomingManageableCompetitions(), 'FETCH_UPCOMING_COMPS');
 }

--- a/tnoodle-ui/src/reducers.js
+++ b/tnoodle-ui/src/reducers.js
@@ -17,6 +17,14 @@ export const versionInfo = function(state=null, action) {
   }
 };
 
+export const records = function(state=null, action) {
+  if(action.type === "FETCH_RECORDS" && action.status === "success") {
+    return action.response;
+  } else {
+    return state;
+  }
+}
+
 export const competitionJson = function(state=null, action) {
   if(action.type === "FETCH_COMPETITION_JSON" && action.status === "success") {
     return normalizeCompetitionJson(action.response);

--- a/tnoodle-ui/src/reducers.js
+++ b/tnoodle-ui/src/reducers.js
@@ -70,7 +70,7 @@ export const loadCompetitionJsonError = function(state=null, action) {
   }
 }
 
-export const puzzlesPer333mbfAttempt = function(state=28, action) {
+export const puzzlesPer333mbfAttempt = function(state=null, action) {
   if(action.type === "SET_PUZZLES_PER_333MBF_ATTEMPT") {
     return action.puzzlesPer333mbfAttempt;
   } else {


### PR DESCRIPTION
@jfly and I paired up on this. This PR removed the default number of 28 and forces a user to input the number of puzzles for the attempt, and the generate scrambles button stays disabled until a number is entered.

We then decided to add a button to suggest a number to the user. We get the 333mbf WR and calculate the attempts, then round up to the nearest multiple of 7 (that's currently how many scrambles fit on a page).

This fixes #361 