### PR TITLE
Make TNoodle compile with java 10

### DIFF
--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleViewHandler.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleViewHandler.java
@@ -164,8 +164,8 @@ public class ScrambleViewHandler extends SafeHttpServlet {
                     // with some tweaks.
                     DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
                     TranscodingHints hints = new TranscodingHints();
-                    hints.put(ImageTranscoder.KEY_WIDTH, new Float(size.width));
-                    hints.put(ImageTranscoder.KEY_HEIGHT, new Float(size.height));
+                    hints.put(ImageTranscoder.KEY_WIDTH, Float.valueOf(size.width));
+                    hints.put(ImageTranscoder.KEY_HEIGHT, Float.valueOf(size.height));
                     hints.put(ImageTranscoder.KEY_DOM_IMPLEMENTATION, impl);
                     hints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,SVGConstants.SVG_NAMESPACE_URI);
                     hints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,SVGConstants.SVG_NAMESPACE_URI);

--- a/winstone/src/winstone/jndi/resourceFactories/NotImplementedException.java
+++ b/winstone/src/winstone/jndi/resourceFactories/NotImplementedException.java
@@ -1,0 +1,8 @@
+/* The version of winstone we use uses
+ * sun.reflect.generics.reflectiveObjects.NotImplementedException.  This is not
+ * public in openjdk 10.  To work around this, we have a local patch with an
+ * exception of the same name.
+ */
+package winstone.jndi.resourceFactories;
+
+class NotImplementedException extends RuntimeException { }

--- a/winstone/src/winstone/jndi/resourceFactories/WinstoneConnection.java
+++ b/winstone/src/winstone/jndi/resourceFactories/WinstoneConnection.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import winstone.Logger;
 
 /**

--- a/winstone/src/winstone/jndi/resourceFactories/WinstoneDataSource.java
+++ b/winstone/src/winstone/jndi/resourceFactories/WinstoneDataSource.java
@@ -20,8 +20,6 @@ import java.util.Properties;
 
 import javax.sql.DataSource;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import winstone.Logger;
 import winstone.WebAppConfiguration;
 import winstone.WinstoneResourceBundle;


### PR DESCRIPTION
This fixes two issues:
-Our import of winstone uses a NotImplementedException that's a private API and not exposed in java 10.
-The Float() constructors are deprecated, with Float.valueOf() as the suggested replacement.