### PR TITLE
Fix lack of thread safety in SkewbSolver

### DIFF
--- a/scrambles/src/puzzle/PyraminxPuzzle.java
+++ b/scrambles/src/puzzle/PyraminxPuzzle.java
@@ -41,6 +41,7 @@ public class PyraminxPuzzle extends Puzzle {
     public PuzzleStateAndGenerator generateRandomMoves(Random r) {
         PyraminxSolverState state = pyraminxSolver.randomState(r);
         String scramble = pyraminxSolver.generateExactly(state, MIN_SCRAMBLE_LENGTH, false);
+        azzertEquals(scramble.split(" ").length, MIN_SCRAMBLE_LENGTH + state.unsolvedTips());
 
         PuzzleState pState;
         try {

--- a/scrambles/src/puzzle/SkewbPuzzle.java
+++ b/scrambles/src/puzzle/SkewbPuzzle.java
@@ -1,6 +1,7 @@
 package puzzle;
 
 import static net.gnehzr.tnoodle.utils.GwtSafeUtils.azzert;
+import static net.gnehzr.tnoodle.utils.GwtSafeUtils.azzertEquals;
 
 import net.gnehzr.tnoodle.svglite.Color;
 import net.gnehzr.tnoodle.svglite.Svg;
@@ -42,6 +43,7 @@ public class SkewbPuzzle extends Puzzle {
     public PuzzleStateAndGenerator generateRandomMoves(Random r) {
         SkewbSolverState state = skewbSolver.randomState(r);
         String scramble = skewbSolver.generateExactly(state, MIN_SCRAMBLE_LENGTH, r);
+        azzertEquals(scramble.split(" ").length, MIN_SCRAMBLE_LENGTH);
 
         PuzzleState pState;
         try {

--- a/scrambles/src/puzzle/TwoByTwoCubePuzzle.java
+++ b/scrambles/src/puzzle/TwoByTwoCubePuzzle.java
@@ -1,6 +1,7 @@
 package puzzle;
 
 import static net.gnehzr.tnoodle.utils.GwtSafeUtils.azzert;
+import static net.gnehzr.tnoodle.utils.GwtSafeUtils.azzertEquals;
 
 import java.util.Random;
 
@@ -27,6 +28,7 @@ public class TwoByTwoCubePuzzle extends CubePuzzle {
     public PuzzleStateAndGenerator generateRandomMoves(Random r) {
         TwoByTwoState state = twoSolver.randomState(r);
         String scramble = twoSolver.generateExactly(state, TWO_BY_TWO_MIN_SCRAMBLE_LENGTH);
+        azzertEquals(scramble.split(" ").length, TWO_BY_TWO_MIN_SCRAMBLE_LENGTH);
 
         AlgorithmBuilder ab = new AlgorithmBuilder(this, MergingMode.CANONICALIZE_MOVES);
         try {


### PR DESCRIPTION
Instead of having solution_length be a class variable, which leads to thread safety issues causing too-short scrambles when Skewb scrambles are generated in multiple threads.

Multiple threads can simultaneously update solution_length, which can result in shorter-than-expected scrambles being returned by the SkewbSolver.  Instead of returning an 11-move scramble solving the random position as expected, it may return an N-move substring of that scramble.

Additionally, add asserts to make bad scramble lengths an error for 2x2, Skewb, and Pyraminx.  This makes the existing tests fail on my laptop.