### PR TITLE
Change some instances of `Scrambler` to `Scramble Program`.

### DIFF
--- a/webscrambles/WebContent/wca/readme-scramble.md
+++ b/webscrambles/WebContent/wca/readme-scramble.md
@@ -1,4 +1,4 @@
-# TNoodle WCA Scrambler
+# TNoodle WCA Scramble Program
 
 Visit [/scramble](/scramble) to use the scrambler, or go to [/readme](/readme) to see the TNoodle readme.
 

--- a/webscrambles/WebContent/wca/readme-tnoodle.md
+++ b/webscrambles/WebContent/wca/readme-tnoodle.md
@@ -3,7 +3,7 @@
 An http server built to generate scrambles and images for twisty puzzles. Supports json, png, svg, pdf, and zip formats.  It is currently being used by the following programs.
 
 * [TNT](/tnt/) - A new timer aiming to replace CCT.
-* [WCA Scrambler](/scramble) - A WCA-style scrambler. See [its readme](/readme/scramble).
+* [WCA Scramble Program](/scramble) - WCA scramble program. See [its readme](/readme/scramble).
 * [bld.js](/tnt/bld.html) - A bld cycle generator for Pochmann-style combine orient+permute methods.
 
 Looking for something that's missing? Want to contribute? Check out the latest version of the code on [github](http://github.com/thewca/tnoodle)!

--- a/webscrambles/WebContent/wca/scramblegen.html
+++ b/webscrambles/WebContent/wca/scramblegen.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>WCA Scrambler</title>
+<title>WCA Scramble Program</title>
 
 <script type="text/javascript">
     function assert(expr, msg) {


### PR DESCRIPTION
As documented in `README.md`:

> Officially, `TNoodle-WCA` is a scramble program, while a scrambler is a human.
> It is fine to refer to TNoodle as a "scrambler" colloquially, but please try
> to use the official convention wherever possible.