### PR TITLE
Translation of word Competition. This fixes #387

### DIFF
--- a/webscrambles/src/i18n/da.yml
+++ b/webscrambles/src/i18n/da.yml
@@ -18,6 +18,8 @@ da:
         graded: Bedømt af
         #original_hash: 5faa59d
         result: Resultat
+        #original_hash: 1917f4f
+        competition: Konkurrence
         #original_hash: 49debdc
         rule1: Du har 60 minutter til at finde og skrive en løsning.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/de.yml
+++ b/webscrambles/src/i18n/de.yml
@@ -18,6 +18,8 @@ de:
         graded: Ausgewertet von
         #original_hash: 5faa59d
         result: Ergebnis
+        #original_hash: 1917f4f
+        competition: Competition
         #original_hash: 49debdc
         rule1: >-
             Du hast 60 Minuten Zeit, um eine Lösung zu finden und

--- a/webscrambles/src/i18n/es.yml
+++ b/webscrambles/src/i18n/es.yml
@@ -18,6 +18,8 @@ es:
         graded: Corregido por
         #original_hash: 5faa59d
         result: Resultado
+        #original_hash: 1917f4f
+        competition: Competición
         #original_hash: 49debdc
         rule1: Tienes 60 minutos para encontrar y escribir una solución.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/et.yml
+++ b/webscrambles/src/i18n/et.yml
@@ -18,6 +18,8 @@ et:
         graded: Hindaja
         #original_hash: 5faa59d
         result: Tulemus
+        #original_hash: 1917f4f
+        competition: Võistlus
         #original_hash: 49debdc
         rule1: Teil on 60 minutit lahenduskäigu leidmiseks ja kirjapanekuks.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/fi.yml
+++ b/webscrambles/src/i18n/fi.yml
@@ -18,6 +18,8 @@ fi:
         graded: Tarkistaja
         #original_hash: 5faa59d
         result: Tulos
+        #original_hash: 1917f4f
+        competition: Kilpailu
         #original_hash: 49debdc
         rule1: Sinulla on 60 minuuttia aikaa löytää ja kirjoittaa ratkaisu.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/fr.yml
+++ b/webscrambles/src/i18n/fr.yml
@@ -18,6 +18,8 @@ fr:
         graded: Corrigé par
         #original_hash: 5faa59d
         result: Résultat
+        #original_hash: 1917f4f
+        competition: Compétition
         #original_hash: 49debdc
         rule1: Vous avez 60 minutes pour trouver et écrire une solution.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/hr.yml
+++ b/webscrambles/src/i18n/hr.yml
@@ -18,6 +18,8 @@ hr:
         graded: Ocijenio/la
         #original_hash: 5faa59d
         result: Rezultat
+        #original_hash: 1917f4f
+        competition: Natjecanje
         #original_hash: 49debdc
         rule1: Imate 60 minuta za traženje i zapisivanje rješenja.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/hu.yml
+++ b/webscrambles/src/i18n/hu.yml
@@ -18,6 +18,8 @@ hu:
         graded: Ellenőrizte
         #original_hash: 5faa59d
         result: Eredmény
+        #original_hash: 1917f4f
+        competition: Verseny
         #original_hash: 49debdc
         rule1: 60 perced van egy megoldás megtalálására és leírására.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/id.yml
+++ b/webscrambles/src/i18n/id.yml
@@ -18,6 +18,8 @@ id:
         graded: Dinilai oleh
         #original_hash: 5faa59d
         result: Hasil
+        #original_hash: 1917f4f
+        competition: Kompetisi
         #original_hash: 49debdc
         rule1: >-
             Anda memiliki waktu 60 menit untuk mencari dan menuliskan solusi

--- a/webscrambles/src/i18n/it.yml
+++ b/webscrambles/src/i18n/it.yml
@@ -18,6 +18,8 @@ it:
         graded: Controllato da
         #original_hash: 5faa59d
         result: Risultato
+        #original_hash: 1917f4f
+        competition: Competizione
         #original_hash: 49debdc
         rule1: Hai 60 minuti per trovare e scrivere una soluzione.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/ja.yml
+++ b/webscrambles/src/i18n/ja.yml
@@ -18,6 +18,8 @@ ja:
         graded: 採点者名
         #original_hash: 5faa59d
         result: 結果
+        #original_hash: 1917f4f
+        competition: 大会
         #original_hash: 49debdc
         rule1: 制限時間は60分 (解答を探す時間・書く時間の合計) です。
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/ja.yml
+++ b/webscrambles/src/i18n/ja.yml
@@ -19,7 +19,7 @@ ja:
         #original_hash: 5faa59d
         result: 結果
         #original_hash: 1917f4f
-        competition: 大会
+        competition: 大会名
         #original_hash: 49debdc
         rule1: 制限時間は60分 (解答を探す時間・書く時間の合計) です。
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/ko.yml
+++ b/webscrambles/src/i18n/ko.yml
@@ -18,6 +18,8 @@ ko:
         graded: 채점자
         #original_hash: 5faa59d
         result: 결과
+        #original_hash: 1917f4f
+        competition: 대회
         #original_hash: 49debdc
         rule1: 제한시간은 60분이며 60분 안에 답을 찾고 쓰셔야 합니다.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/nb.yml
+++ b/webscrambles/src/i18n/nb.yml
@@ -18,6 +18,8 @@ nb:
         graded: Vurdert av
         #original_hash: 5faa59d
         result: Resultat
+        #original_hash: 1917f4f
+        competition: Konkurranse
         #original_hash: 49debdc
         rule1: Du har 60 minutter på å finne og skrive ned en løsning.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/pl.yml
+++ b/webscrambles/src/i18n/pl.yml
@@ -18,6 +18,8 @@ pl:
         graded: Ocenione przez
         #original_hash: 5faa59d
         result: Rezultat
+        #original_hash: 1917f4f
+        competition: Zawody
         #original_hash: 49debdc
         rule1: Masz 60 minut na znalezienie i zapisanie rozwiązania.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/pt-BR.yml
+++ b/webscrambles/src/i18n/pt-BR.yml
@@ -18,6 +18,8 @@ pt-BR:
         graded: Verificado por
         #original_hash: 5faa59d
         result: Resultado
+        #original_hash: 1917f4f
+        competition: Competição
         #original_hash: 49debdc
         rule1: Você tem 60 minutos para encontrar e escrever uma solução.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/pt.yml
+++ b/webscrambles/src/i18n/pt.yml
@@ -18,6 +18,8 @@ pt:
         graded: Avaliado por
         #original_hash: 5faa59d
         result: Resultado
+        #original_hash: 1917f4f
+        competition: Competição
         #original_hash: 49debdc
         rule1: Tem 60 minutos para encontrar e escrever uma solução.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/ro.yml
+++ b/webscrambles/src/i18n/ro.yml
@@ -18,6 +18,8 @@ ro:
         graded: 'Verificat de:'
         #original_hash: 5faa59d
         result: Rezultat
+        #original_hash: 1917f4f
+        competition: Competiție
         #original_hash: 49debdc
         rule1: Ai 60 de minute să găsești și să scrii o soluție.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/ru.yml
+++ b/webscrambles/src/i18n/ru.yml
@@ -18,6 +18,8 @@ ru:
         graded: Проверил(а)
         #original_hash: 5faa59d
         result: Результат
+        #original_hash: 1917f4f
+        competition: Соревнование
         #original_hash: 49debdc
         rule1: У вас есть 60 минут на поиск и запись решения.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/sl.yml
+++ b/webscrambles/src/i18n/sl.yml
@@ -18,6 +18,8 @@ sl:
         graded: Ocenil
         #original_hash: 5faa59d
         result: Rezultat
+        #original_hash: 1917f4f
+        competition: Tekmovanje
         #original_hash: 49debdc
         rule1: 'Na voljo je 60 minut, da se najde in zapiše rešitev.'
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/vi.yml
+++ b/webscrambles/src/i18n/vi.yml
@@ -18,6 +18,8 @@ vi:
         graded: Được đánh giá bởi
         #original_hash: 5faa59d
         result: Kết quả
+        #original_hash: 1917f4f
+        competition: Giải đấu
         #original_hash: 49debdc
         rule1: Bạn có 60 phút để tìm và viết một cách giải.
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/zh-CN.yml
+++ b/webscrambles/src/i18n/zh-CN.yml
@@ -18,6 +18,8 @@ zh-CN:
         graded: 阅卷人
         #original_hash: 5faa59d
         result: 成绩
+        #original_hash: 1917f4f
+        competition: 比赛
         #original_hash: 49debdc
         rule1: 你有一小时的时间寻找解法。
         #original_hash: 8b6b48b

--- a/webscrambles/src/i18n/zh-TW.yml
+++ b/webscrambles/src/i18n/zh-TW.yml
@@ -18,6 +18,8 @@ zh-TW:
         graded: 閱卷人
         #original_hash: 5faa59d
         result: 成績
+        #original_hash: 1917f4f
+        competition: 比賽
         #original_hash: 49debdc
         rule1: 您有60分鐘的時間尋找並寫出解法。
         #original_hash: 8b6b48b


### PR DESCRIPTION
We went ahead and used [available translations](https://github.com/thewca/worldcubeassociation.org/blob/2cb584729c1acfcffd3e16740abcdf88d7685ec3/WcaOnRails/config/locales/en.yml#L330). Merging after translators are ok with it.