### PR TITLE
Fix style of FMC cutout sheet. This also fixes #394

### DIFF
--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
@@ -869,8 +869,8 @@ class ScrambleRequest {
 
         BaseFont bf = getFontForLocale(Translate.DEFAULT_LOCALE);
 
-        int bottom = 30;
-        int left = 35;
+        int bottom = 10;
+        int left = 20;
         int right = (int) (pageSize.getWidth()-left);
         int top = (int) (pageSize.getHeight()-bottom);
 

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
@@ -530,7 +530,7 @@ class ScrambleRequest {
         // Competitor info left border
         cb.moveTo(competitorInfoLeft, gradeBottom);
         cb.lineTo(competitorInfoLeft, top);
-        
+
         // Solution lines
         int availableSolutionWidth = right - left;
         int availableSolutionHeight = scrambleBorderTop - bottom;
@@ -597,33 +597,32 @@ class ScrambleRequest {
         }
 
         int fontSize = 15;
-        int marginBottom = 10;
         int margin = 5;
         boolean showScrambleCount = withScramble && scrambleRequest.scrambles.length > 1;
 
         Rectangle competitorInfoRect = new Rectangle(competitorInfoLeft+margin, top, right-margin, competitorInfoBottom);
         Rectangle gradeRect = new Rectangle(competitorInfoLeft+margin, competitorInfoBottom, right-margin, gradeBottom);
         Rectangle scrambleImageRect = new Rectangle(competitorInfoLeft+margin, gradeBottom, right-margin, scrambleBorderTop);
-        
+
         String shortFill = ": ____";
         String longFill = ": __________________";
 
         // competitor and competition info
         ArrayList<String> list = new ArrayList<String>();
         ArrayList<Integer> alignList = new ArrayList<Integer>();
-        
+
         if(withScramble) {
             list.add(globalTitle);
             alignList.add(Element.ALIGN_CENTER);
             list.add(scrambleRequest.title);
             alignList.add(Element.ALIGN_CENTER);
-            
+
             if(showScrambleCount) {
 
                 HashMap<String, String> substitutions = new HashMap<String, String>();
                 substitutions.put("scrambleIndex", ""+(index+1));
                 substitutions.put("scrambleCount", ""+(scrambleRequest.scrambles.length));
-                
+
                 list.add(translate("fmc.scrambleXofY", locale, substitutions));
                 alignList.add(Element.ALIGN_CENTER);
             }
@@ -652,7 +651,7 @@ class ScrambleRequest {
             alignList.add(Element.ALIGN_LEFT);
         }
         populateRect(cb, competitorInfoRect, list, alignList, bf, fontSize);
-        
+
         // graded
         fontSize = 11;
         list = new ArrayList<String>();
@@ -663,22 +662,22 @@ class ScrambleRequest {
         alignList.add(Element.ALIGN_CENTER);
         fontSize = 11;
         populateRect(cb, gradeRect, list, alignList, bf, fontSize);
-        
+
         if(!withScramble) {
             fontSize = 11;
-            
+
             list = new ArrayList<String>();
             alignList = new ArrayList<Integer>();
-            
+
             list.add(""); // fake vertical centering
             alignList.add(Element.ALIGN_CENTER);
 
             list.add(translate("fmc.scrambleOnSeparateSheet", locale));
             alignList.add(Element.ALIGN_CENTER);
-            
+
             populateRect(cb, scrambleImageRect, list, alignList, bf, fontSize);
         }
-        
+
         int fmcMargin = 10;
 
         // Table
@@ -689,7 +688,7 @@ class ScrambleRequest {
         int cellHeight = tableHeight/tableLines;
         int columns = 7;
         int firstColumnWidth = tableWidth-(columns-1)*cellWidth;
-        
+
         int movesFontSize = 10;
         Font movesFont = new Font(bf, movesFontSize);
 
@@ -721,7 +720,7 @@ class ScrambleRequest {
                 movesCell[1][i][j] = "["+moves[j].toLowerCase()+directionModifiers[i]+"]";
             }
         }
-        
+
         Rectangle firstColumnRectangle = new Rectangle(firstColumnWidth, cellHeight);
         float firstColumnFontSize = fitText(new Font(bf), movesType[0], firstColumnRectangle, 10, false, 1f);
 
@@ -785,10 +784,10 @@ class ScrambleRequest {
         int MAGIC_NUMBER = 30; // kill me now
         float leadingMultiplier = 1;
         fontSize = 25;
-        
+
         Rectangle rect = new Rectangle(left, top-MAGIC_NUMBER+fontSize, competitorInfoLeft, top-MAGIC_NUMBER);
         fitAndShowText(cb, translate("fmc.event", locale), bf, rect, fontSize, Element.ALIGN_CENTER, leadingMultiplier);
-        
+
         ArrayList<String> rulesList = new ArrayList<String>();
         rulesList.add("• "+translate("fmc.rule1", locale));
         rulesList.add("• "+translate("fmc.rule2", locale));
@@ -804,7 +803,7 @@ class ScrambleRequest {
         rulesList.add("• "+translate("fmc.rule6", locale));
 
         int rulesTop = competitorInfoBottom + (withScramble ? 65 : 153);
-        
+
         leadingMultiplier = 1.5f;
         Rectangle rulesRectangle = new Rectangle(left+fmcMargin, scrambleBorderTop+tableHeight+fmcMargin, competitorInfoLeft-fmcMargin, rulesTop+fmcMargin);
         String rules = String.join("\n", rulesList);
@@ -812,7 +811,7 @@ class ScrambleRequest {
 
         doc.newPage();
     }
-    
+
     private static void fitAndShowText(PdfContentByte cb, String text, BaseFont bf, Rectangle rect, float maxFontSize, int align, float leadingMultiplier) throws DocumentException {
         // We create a temp pdf and check if the text fit in a rectangle there.
         // If it's ok, we add the text to original pdf.
@@ -837,33 +836,34 @@ class ScrambleRequest {
                 ct.go();
                 break;
             }
-            
+
             maxFontSize -= 0.1;
         } while(true);
     }
-    
+
     private static void populateRect(PdfContentByte cb, Rectangle rect, ArrayList<String> list, ArrayList<Integer> alignList, BaseFont bf, int fontSize)  throws DocumentException {
-        
+
         azzert(list.size() == alignList.size(), "Make sure list.size() == alignList.size()");
 
         float totalHeight = rect.getHeight();
         float width = rect.getWidth();
         float x = rect.getLeft();
         float y = rect.getTop();
-        
+
         float height = totalHeight/(list.size());
-        
+
         for (int i=0; i<list.size(); i++) {
             Rectangle temp = new Rectangle(x, y+height*i-totalHeight-fontSize, x+width, y+height*i-totalHeight);
             fitAndShowText(cb, list.get(i), bf, temp, 15, alignList.get(i), 1f);
         }
     }
-    
+
     private static void addGenericFmcSolutionSheet(PdfWriter docWriter, Document doc, String globalTitle, Locale locale) throws DocumentException, IOException {
         addFmcSolutionSheet(docWriter, doc, null, globalTitle, -1, locale);
     }
 
     private static void addFmcScrambleCutoutSheet(PdfWriter docWriter, Document doc, ScrambleRequest scrambleRequest, String globalTitle, int index) throws DocumentException, IOException {
+
         Rectangle pageSize = doc.getPageSize();
         String scramble = scrambleRequest.scrambles[index];
         PdfContentByte cb = docWriter.getDirectContent();
@@ -914,18 +914,16 @@ class ScrambleRequest {
         final int scramblesPerSheet = 8;
         for (int y = 0; y < scramblesPerSheet; y++) {
             cb.beginText();
-            String title = "";
+            String title = globalTitle + " - " + scrambleRequest.title;
             if(scrambleRequest.scrambles.length > 1) {
-                title = globalTitle + " - " + scrambleRequest.title + " - Scramble " + (index + 1) + " of " + scrambleRequest.scrambles.length + ":";
-            } else {
-                title = globalTitle + " - " + scrambleRequest.title + ":";
+                title += " - Scramble " + (index + 1) + " of " + scrambleRequest.scrambles.length;
             }
 
             fontSize = fitText(new Font(bf), title, new Rectangle(availableScrambleSpace, 100), scrambleFontSize, false, 1f);
 
             cb.setFontAndSize(bf, fontSize);
             cb.showTextAligned(PdfContentByte.ALIGN_LEFT, title, left, top - offsetTop, 0);
-            cb.showTextAligned(PdfContentByte.ALIGN_LEFT, globalTitle + " - " + scrambleRequest.title + ":", left, top - offsetTop, 0);
+            cb.showTextAligned(PdfContentByte.ALIGN_LEFT, globalTitle + " - " + scrambleRequest.title, left, top - offsetTop, 0);
             cb.endText();
             offsetTop += fontSize + marginBottom;
 
@@ -1387,6 +1385,8 @@ class ScrambleRequest {
                     doc.addTitle(globalTitle);
                 }
 
+                // perhaps we should use i18n on the cutout sheet (scramblexofY)
+                // and place it with the other internationalized pdfs
                 doc.open();
                 for (int i = 0; i < scrambleRequest.scrambles.length; i++) {
                     addFmcScrambleCutoutSheet(docWriter, doc, scrambleRequest, globalTitle, i);

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleRequest.java
@@ -146,7 +146,6 @@ class ScrambleRequest {
     // This is here just to make GSON work.
     public ScrambleRequest(){}
 
-
     public String[] scrambles;
     public String[] extraScrambles = new String[0];
     public Puzzle scrambler;
@@ -885,11 +884,7 @@ class ScrambleRequest {
 
         int availableScrambleSpace = width - padding;
         int scrambleFontSize = 20;
-        float scrambleWidth;
-        do {
-            scrambleFontSize--;
-            scrambleWidth = bf.getWidthPoint(scramble, scrambleFontSize);
-        } while (scrambleWidth > availableScrambleSpace);
+        int titleFontSize = 15;
 
         int availableScrambleWidth = (int) (width * .45);
         int availableScrambleHeight = height - (int) (height * .77) - 90;
@@ -913,25 +908,21 @@ class ScrambleRequest {
 
         final int scramblesPerSheet = 8;
         for (int y = 0; y < scramblesPerSheet; y++) {
-            cb.beginText();
+
             String title = globalTitle + " - " + scrambleRequest.title;
             if(scrambleRequest.scrambles.length > 1) {
                 title += " - Scramble " + (index + 1) + " of " + scrambleRequest.scrambles.length;
             }
+            
+            Rectangle rect = new Rectangle(left, top - offsetTop, left+availableScrambleSpace, top - offsetTop + scrambleFontSize);
+            fitAndShowText(cb, title, bf, rect, titleFontSize, Element.ALIGN_LEFT, 1);
 
-            fontSize = fitText(new Font(bf), title, new Rectangle(availableScrambleSpace, 100), scrambleFontSize, false, 1f);
-
-            cb.setFontAndSize(bf, fontSize);
-            cb.showTextAligned(PdfContentByte.ALIGN_LEFT, title, left, top - offsetTop, 0);
-            cb.showTextAligned(PdfContentByte.ALIGN_LEFT, globalTitle + " - " + scrambleRequest.title, left, top - offsetTop, 0);
-            cb.endText();
             offsetTop += fontSize + marginBottom;
+            
+            rect = new Rectangle(left, top - offsetTop, left+availableScrambleSpace, top - offsetTop + scrambleFontSize);
+            fitAndShowText(cb, scramble, bf, rect, scrambleFontSize, Element.ALIGN_LEFT, 1);
 
-            cb.beginText();
-            cb.setFontAndSize(bf, scrambleFontSize);
-            cb.showTextAligned(PdfContentByte.ALIGN_LEFT, scramble, left, top - offsetTop, 0);
             offsetTop += scrambleFontSize + marginBottom;
-            cb.endText();
 
             cb.addImage(Image.getInstance(tp), dim.width, 0, 0, dim.height, right - padding, top - offsetTop - 1);
 
@@ -1385,8 +1376,7 @@ class ScrambleRequest {
                     doc.addTitle(globalTitle);
                 }
 
-                // perhaps we should use i18n on the cutout sheet (scramblexofY)
-                // and place it with the other internationalized pdfs
+                // TODO: i18n. See https://github.com/thewca/tnoodle/issues/396
                 doc.open();
                 for (int i = 0; i < scrambleRequest.scrambles.length; i++) {
                     addFmcScrambleCutoutSheet(docWriter, doc, scrambleRequest, globalTitle, i);


### PR DESCRIPTION
We used to end the competition name with a colon

![captura de tela de 2019-02-11 14-55-09](https://user-images.githubusercontent.com/10170850/52583227-37b0c280-2e16-11e9-88a6-0c1b5c6507d4.png)

Eventually, there was a colon mixed with a hyphen.

![captura de tela de 2019-02-11 14-55-54](https://user-images.githubusercontent.com/10170850/52583374-94ac7880-2e16-11e9-831e-b1fae4446535.png)

Colon has been removed

Updates with the latest commit (drop the use of several arbitrary number and better space use).

![cutout](https://user-images.githubusercontent.com/10170850/53306659-b6721a80-386e-11e9-90cf-1f48328d69de.png)

![cutout2](https://user-images.githubusercontent.com/10170850/53306661-b96d0b00-386e-11e9-82f9-30cc8ee0f5d8.png)