### PR TITLE
windows-1252 to utf-8 for PDFs fix #177

### DIFF
--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleViewHandler.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleViewHandler.java
@@ -243,10 +243,17 @@ public class ScrambleViewHandler extends SafeHttpServlet {
 
                 sendBytes(request, response, totalPdfOutput, "application/pdf");
             } else if (extension.equals("zip")) {
+                
+                byte[] sourceBytes = globalTitle.getBytes("windows-1252");
+                globalTitle = new String(sourceBytes , "UTF-8");
+                
                 ByteArrayOutputStream zipOutput = ScrambleRequest
                         .requestsToZip(getServletContext(), globalTitle, generationDate, scrambleRequests, password, generationUrl);
+                
                 String safeTitle = globalTitle.replaceAll("\"", "'");
+
                 response.setHeader("Content-Disposition", "attachment; filename=\"" + safeTitle + ".zip\"");
+                
                 sendBytes(request, response, zipOutput, "application/zip");
             } else {
                 azzert(false);


### PR DESCRIPTION
This doesn't fix how the file names are displayed, but fixes how they are rendered on the .pdf

![Captura de tela de 2019-03-23 13-35-01](https://user-images.githubusercontent.com/10170850/54869020-ad8f3e80-4d71-11e9-9602-0dd132310d1a.png)


![Captura de tela de 2019-03-23 13-38-31](https://user-images.githubusercontent.com/10170850/54869022-b253f280-4d71-11e9-9426-870ca6586c09.png)

I'm sure a best approach would be really [dropping](https://github.com/thewca/tnoodle/issues/177#issuecomment-475839267) windows-1252 to utf-8.