### PR TITLE
Optimise :tnoodle-ui Gradle subproject

### DIFF
--- a/tnoodle-ui/build.gradle.kts
+++ b/tnoodle-ui/build.gradle.kts
@@ -15,11 +15,12 @@ configure<NodeExtension> {
 tasks.create<YarnTask>("bundle") {
     dependsOn("yarn_install")
 
-    inputs.files(fileTree("src"))
-    inputs.files(fileTree("public"))
+    inputs.files(fileTree("src").exclude("*.css"))
+    inputs.dir("public")
     inputs.file("package.json")
 
     outputs.dir("${project.buildDir}/static")
+    outputs.file("${project.buildDir}/index.html")
 
     setYarnCommand("build")
 }
@@ -32,7 +33,7 @@ tasks.getByName("yarn_install") {
 }
 
 tasks.getByName("assemble") {
-    dependsOn("bundle", "packageReactFrontend")
+    dependsOn("packageReactFrontend")
 }
 
 tasks.getByName("check") {
@@ -58,7 +59,5 @@ tasks.create<Zip>("packageReactFrontend") {
         into("wca/new-ui")
     }
 
-    artifacts {
-      add("reactYarnBundle", this@create)
-    }
+    artifacts.add("reactYarnBundle", this)
 }

--- a/tnoodle-ui/build.gradle.kts
+++ b/tnoodle-ui/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.moowork.gradle.node.NodeExtension
-import com.moowork.gradle.node.yarn.YarnTask
 
 description = "A web ui for TNoodle that uses modern technology, and interacts with the WCA website api to minimize repeated data entry."
 
@@ -12,7 +11,7 @@ configure<NodeExtension> {
     download = true
 }
 
-tasks.create<YarnTask>("bundle") {
+tasks.getByName("yarn_build") {
     dependsOn("yarn_install")
 
     inputs.files(fileTree("src").exclude("*.css"))
@@ -21,8 +20,6 @@ tasks.create<YarnTask>("bundle") {
 
     outputs.dir("${project.buildDir}/static")
     outputs.file("${project.buildDir}/index.html")
-
-    setYarnCommand("build")
 }
 
 tasks.getByName("yarn_install") {
@@ -41,15 +38,17 @@ tasks.getByName("check") {
 }
 
 tasks.getByName("yarn_test") {
-    dependsOn("bundle")
+    dependsOn("yarn_build")
 }
 
-configurations.create("reactYarnBundle")
+configurations.create("reactFrontendBundle") {
+    configurations.getByName("default").extendsFrom(this)
+}
 
 tasks.create<Zip>("packageReactFrontend") {
-    dependsOn("bundle")
+    dependsOn("yarn_build")
 
-    archiveBaseName.set("npm-react-app")
+    archiveBaseName.set("react-frontend")
     archiveExtension.set("jar")
 
     from("${project.buildDir}") {
@@ -59,5 +58,5 @@ tasks.create<Zip>("packageReactFrontend") {
         into("wca/new-ui")
     }
 
-    artifacts.add("reactYarnBundle", this)
+    artifacts.add("reactFrontendBundle", this)
 }

--- a/tnoodle-ui/build.gradle.kts
+++ b/tnoodle-ui/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     NODEJS
 }
 
-configure<NodeExtension> { 
+configure<NodeExtension> {
     download = true
 }
 
@@ -24,18 +24,6 @@ tasks.create<YarnTask>("bundle") {
     setYarnCommand("build")
 }
 
-tasks.create<Copy>("propagateResources") {
-    dependsOn("bundle")
-
-    from("${project.buildDir}") {
-        include("static/**/*")
-        include("*.html")
-    }
-
-    val targetBaseDir = project(":webscrambles").buildDir
-    into("$targetBaseDir/resources/main/wca/new-ui")
-}
-
 tasks.getByName("yarn_install") {
     inputs.file("package.json")
     inputs.file("yarn.lock")
@@ -44,7 +32,7 @@ tasks.getByName("yarn_install") {
 }
 
 tasks.getByName("assemble") {
-    dependsOn("bundle", "propagateResources")
+    dependsOn("bundle", "packageReactFrontend")
 }
 
 tasks.getByName("check") {
@@ -53,4 +41,24 @@ tasks.getByName("check") {
 
 tasks.getByName("yarn_test") {
     dependsOn("bundle")
+}
+
+configurations.create("reactYarnBundle")
+
+tasks.create<Zip>("packageReactFrontend") {
+    dependsOn("bundle")
+
+    archiveBaseName.set("npm-react-app")
+    archiveExtension.set("jar")
+
+    from("${project.buildDir}") {
+        include("static/**/*")
+        include("*.html")
+
+        into("wca/new-ui")
+    }
+
+    artifacts {
+      add("reactYarnBundle", this@create)
+    }
 }

--- a/webscrambles/build.gradle.kts
+++ b/webscrambles/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation(SNAKEYAML)
     implementation(BOUNCYCASTLE)
 
-    runtime(project(":tnoodle-ui", "reactYarnBundle"))
+    runtime(project(":tnoodle-ui"))
 }
 
 tasks.withType<KotlinCompile> {

--- a/webscrambles/build.gradle.kts
+++ b/webscrambles/build.gradle.kts
@@ -41,15 +41,11 @@ dependencies {
     implementation(SNAKEYAML)
     implementation(BOUNCYCASTLE)
 
-    runtime(project(":tnoodle-ui"))
+    runtime(project(":tnoodle-ui", "reactYarnBundle"))
 }
 
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
-}
-
-tasks.getByName("processResources") {
-    dependsOn(":tnoodle-ui:assemble")
 }
 
 application {


### PR DESCRIPTION
The `tnoodle-ui` subproject is currently using a third-party plugin to facilitate handling the `yarn` JS environment. As such, my first integration was quite "hacky" and I learned a ton of new stuff in the meantime -- most importantly how to properly share resources between subprojects.

I would be tempted to just merge this as-is, because this PR only changes **how** the Gradle project is built. It doesn't actually touch any part of **what** is being built.

T-72 for spontaneous reviews, otherwise I will just trust the CI.