### PR TITLE
Bump several external library versions

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -3,21 +3,21 @@ package dependencies
 object Versions {
     val GWT = "2.5.1"
     val JUNIT_JUPITER = "5.4.2"
-    val BATIK = "1.11"
-    val KOTLIN = "1.3.50"
-    val KTOR = "1.2.0"
-    val PROGUARD = "6.1.1"
+    val BATIK = "1.12"
+    val KOTLIN = "1.3.60"
+    val KTOR = "1.2.4"
+    val PROGUARD = "6.2.0"
 
     val GWTEXPORTER = GWT
     val MARKDOWNJ_CORE = "0.4"
     val JODA_TIME = "2.10.1"
-    val ZIP4J = "2.2.1"
-    val ITEXTPDF = "5.5.13"
+    val ZIP4J = "2.2.4"
+    val ITEXTPDF = "5.5.13.1"
     val BATIK_TRANSCODER = BATIK
-    val SNAKEYAML = "1.24"
+    val SNAKEYAML = "1.25"
     val NATIVE_TRAY_ADAPTER = "1.2-SNAPSHOT"
     val APPLEJAVAEXTENSIONS = "1.4"
-    val BOUNCYCASTLE = "1.61"
+    val BOUNCYCASTLE = "1.64"
     val JUNIT_JUPITER_API = JUNIT_JUPITER
     val JUNIT_JUPITER_ENGINE = JUNIT_JUPITER
     val KOTLIN_STDLIB_JVM = KOTLIN
@@ -33,7 +33,7 @@ object Versions {
     val WCA_I18N = "0.4.3"
 
     object Plugins {
-        val SHADOW = "5.0.0"
+        val SHADOW = "5.2.0"
         val NODEJS = "1.3.1"
 
         val KOTLIN = Versions.KOTLIN


### PR DESCRIPTION
I opted for a round-house version upgrading frenzy, because a new Kotlin version has been released as well as ProGuard 6.2.0 containing some significant optimization improvements.

Offline JAR file drops almost by 1MB