### PR TITLE
Migrate Joda to J8 DateTime (fixes #400)

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Libraries.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Libraries.kt
@@ -3,7 +3,6 @@ package dependencies
 object Libraries {
     val GWTEXPORTER = "org.timepedia.exporter:gwtexporter:${Versions.GWTEXPORTER}"
     val MARKDOWNJ_CORE = "org.markdownj:markdownj-core:${Versions.MARKDOWNJ_CORE}"
-    val JODA_TIME = "joda-time:joda-time:${Versions.JODA_TIME}"
     val ZIP4J = "net.lingala.zip4j:zip4j:${Versions.ZIP4J}"
     val ITEXTPDF = "com.itextpdf:itextpdf:${Versions.ITEXTPDF}"
     val BATIK_TRANSCODER = "org.apache.xmlgraphics:batik-transcoder:${Versions.BATIK_TRANSCODER}"

--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -10,7 +10,6 @@ object Versions {
 
     val GWTEXPORTER = GWT
     val MARKDOWNJ_CORE = "0.4"
-    val JODA_TIME = "2.10.1"
     val ZIP4J = "2.2.4"
     val ITEXTPDF = "5.5.13.1"
     val BATIK_TRANSCODER = BATIK

--- a/webscrambles/build.gradle.kts
+++ b/webscrambles/build.gradle.kts
@@ -4,7 +4,6 @@ import configurations.Languages.attachRemoteRepositories
 import dependencies.Libraries.BATIK_TRANSCODER
 import dependencies.Libraries.BOUNCYCASTLE
 import dependencies.Libraries.ITEXTPDF
-import dependencies.Libraries.JODA_TIME
 import dependencies.Libraries.SNAKEYAML
 import dependencies.Libraries.ZIP4J
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -35,7 +34,6 @@ dependencies {
     implementation(project(":scrambles"))
     implementation(project(":server-ktor"))
 
-    implementation(JODA_TIME)
     implementation(ZIP4J)
     implementation(ITEXTPDF)
     implementation(BATIK_TRANSCODER)

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/Activity.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/Activity.kt
@@ -1,8 +1,9 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
 
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 data class Activity(val activityCode: String, val startTime: String) {
-    fun getLocalStartTime(timeZone: DateTimeZone) = DateTime(startTime, timeZone)
+    fun getLocalStartTime(timeZone: ZoneId) = ZonedDateTime.of(LocalDateTime.parse(startTime), timeZone)
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/Activity.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/Activity.kt
@@ -5,5 +5,5 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 
 data class Activity(val activityCode: String, val startTime: String) {
-    fun getLocalStartTime(timeZone: ZoneId) = ZonedDateTime.of(LocalDateTime.parse(startTime), timeZone)
+    fun getLocalStartTime(timeZone: ZoneId) = ZonedDateTime.of(LocalDateTime.parse(startTime, WCIFHelper.WCIF_DATE_FORMAT), timeZone)
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/OrderedScrambles.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/OrderedScrambles.kt
@@ -2,17 +2,17 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
 
 import net.lingala.zip4j.io.outputstream.ZipOutputStream
 import net.lingala.zip4j.model.ZipParameters
-import org.joda.time.DateTime
-import org.joda.time.Days
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.filterForActivity
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.atStartOfDay
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest.Companion.putFileEntry
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.ZonedDateTime
 
 import java.util.Date
 
 object OrderedScrambles {
-    // TODO see https://github.com/thewca/tnoodle/issues/400
-
     fun generateOrderedScrambles(scrambleRequests: List<ScrambleRequest>, globalTitle: String?, generationDate: Date, zipOut: ZipOutputStream, parameters: ZipParameters, wcifHelper: WCIFHelper) {
         if (wcifHelper.venues.isEmpty()) {
             return
@@ -30,14 +30,14 @@ object OrderedScrambles {
             val hasMultipleRooms = venue.hasMultipleRooms
 
             val timezone = venue.dateTimeZone
-            val competitionStartDate = DateTime(competitionStartString, timezone)
+            val competitionStartDate = ZonedDateTime.of(LocalDateTime.parse(competitionStartString), timezone)
 
             for (room in venue.rooms) {
                 val roomName = room.fileSafeName
 
                 val requestsPerDay = room.activities
                     .flatMap { scrambleRequests.filterForActivity(it, timezone) }
-                    .groupBy { Days.daysBetween(competitionStartDate.withTimeAtStartOfDay(), it.second.withTimeAtStartOfDay()).days + 1 }
+                    .groupBy { Period.between(competitionStartDate.atStartOfDay(), it.second.atStartOfDay()).days + 1 }
 
                 // hasMultipleDays gets a variable assigned on the competition creation using the website's form.
                 // Online schedule fit to it and the user should not be able to put events outside it, but we double check here.

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/OrderedScrambles.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/OrderedScrambles.kt
@@ -6,6 +6,7 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.filterForActivity
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.atStartOfDay
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest.Companion.putFileEntry
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.WCIF_DATE_FORMAT
 import java.time.LocalDateTime
 import java.time.Period
 import java.time.ZonedDateTime
@@ -30,7 +31,7 @@ object OrderedScrambles {
             val hasMultipleRooms = venue.hasMultipleRooms
 
             val timezone = venue.dateTimeZone
-            val competitionStartDate = ZonedDateTime.of(LocalDateTime.parse(competitionStartString), timezone)
+            val competitionStartDate = ZonedDateTime.of(LocalDateTime.parse(competitionStartString, WCIF_DATE_FORMAT), timezone)
 
             for (room in venue.rooms) {
                 val roomName = room.fileSafeName

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/Venue.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/Venue.kt
@@ -1,11 +1,11 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
 
-import org.joda.time.DateTimeZone
+import java.time.ZoneId
 
 data class Venue(val name: String, val rooms: List<Room>, val timezone: String) : SafeNamed(name) {
     val hasMultipleRooms: Boolean
         get() = rooms.size > 1
 
-    val dateTimeZone: DateTimeZone
-        get() = DateTimeZone.forID(timezone)
+    val dateTimeZone: ZoneId
+        get() = ZoneId.of(timezone)
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFHelper.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFHelper.kt
@@ -3,9 +3,9 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 import kotlin.math.pow
 
@@ -45,7 +45,7 @@ class WCIFHelper(schedule: String) {
             .flatMap { it.rooms }
             .flatMap { it.activities }
             .map { it.startTime }
-            .minBy { DateTime.parse(it) } ?: error("I could not find the earliest activity")
+            .minBy { ZonedDateTime.parse(it) } ?: error("I could not find the earliest activity")
 
     val hasMultipleDays: Boolean get() = numberOfDays > 1
     val hasMultipleVenues: Boolean get() = venues.size > 1
@@ -53,7 +53,7 @@ class WCIFHelper(schedule: String) {
     companion object {
         private val PARSER = JsonParser()
 
-        fun List<ScrambleRequest>.filterForActivity(activity: Activity, timeZone: DateTimeZone): List<Pair<ScrambleRequest, DateTime>> {
+        fun List<ScrambleRequest>.filterForActivity(activity: Activity, timeZone: ZoneId): List<Pair<ScrambleRequest, ZonedDateTime>> {
             val activitySplit = activity.activityCode.split("-".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
             val event = activitySplit[0]
 
@@ -96,6 +96,8 @@ class WCIFHelper(schedule: String) {
 
             return mappedRequests.takeIf { it.isNotEmpty() } ?: error("An activity of the schedule did not match an event.")
         }
+
+        fun ZonedDateTime.atStartOfDay() = toLocalDate().atStartOfDay().toLocalDate()
 
         fun compareLettersCharToNumber(letters: String, number: Int): Boolean {
             val sum = letters.reversed().withIndex().sumBy { (i, c) ->

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFHelper.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFHelper.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 import kotlin.math.pow
 
@@ -45,13 +46,16 @@ class WCIFHelper(schedule: String) {
             .flatMap { it.rooms }
             .flatMap { it.activities }
             .map { it.startTime }
-            .minBy { ZonedDateTime.parse(it) } ?: error("I could not find the earliest activity")
+            .minBy { ZonedDateTime.parse(it, WCIF_DATE_FORMAT) }
+            ?: error("I could not find the earliest activity")
 
     val hasMultipleDays: Boolean get() = numberOfDays > 1
     val hasMultipleVenues: Boolean get() = venues.size > 1
 
     companion object {
         private val PARSER = JsonParser()
+
+        val WCIF_DATE_FORMAT = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
         fun List<ScrambleRequest>.filterForActivity(activity: Activity, timeZone: ZoneId): List<Pair<ScrambleRequest, ZonedDateTime>> {
             val activitySplit = activity.activityCode.split("-".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
@@ -94,7 +98,8 @@ class WCIFHelper(schedule: String) {
                 scramblesForAttempt to activityTime
             }
 
-            return mappedRequests.takeIf { it.isNotEmpty() } ?: error("An activity of the schedule did not match an event.")
+            return mappedRequests.takeIf { it.isNotEmpty() }
+                ?: error("An activity of the schedule did not match an event.")
         }
 
         fun ZonedDateTime.atStartOfDay() = toLocalDate().atStartOfDay().toLocalDate()


### PR DESCRIPTION
Addresses #400

We don't need Joda anymore now that Java has a reliable and (somewhat) clean DateTime implementation on board.

This also saves us one library that we would need to package for the Delegates otherwise.