### PR TITLE
Minor javadoc fixes

### DIFF
--- a/min2phase/src/main/java/cs/min2phase/Search.java
+++ b/min2phase/src/main/java/cs/min2phase/Search.java
@@ -1,4 +1,4 @@
-/**
+/*
     Copyright (C) 2015  Shuang Chen
 
     This program is free software: you can redistribute it and/or modify
@@ -158,7 +158,7 @@ public class Search {
 	 *
 	 * @param probeMin
 	 *      defines the minimum number of the probes of phase 2. So, if a solution is found within given probes, the
-	 *      computing will continue to find shorter solution(s). Btw, if probeMin > probeMax, probeMin will be set to probeMax.
+	 *      computing will continue to find shorter solution(s). Btw, if probeMin &gt; probeMax, probeMin will be set to probeMax.
 	 *
 	 * @param verbose
 	 *      determins the format of the solution(s). see USE_SEPARATOR, INVERSE_SOLUTION, APPEND_LENGTH, OPTIMAL_SOLUTION

--- a/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/PyraminxSolver.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/PyraminxSolver.java
@@ -387,6 +387,7 @@ public class PyraminxSolver {
     /**
      * Generate a random pyraminx position.
      * @param r         random int generator
+     * @return          A randomised Pyraminx state, based on the seeding of {@code r}
      */
     public PyraminxSolverState randomState(Random r) {
         PyraminxSolverState state = new PyraminxSolverState();

--- a/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/PyraminxSolver.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/PyraminxSolver.java
@@ -76,7 +76,7 @@ public class PyraminxSolver {
 
     /**
      * Converts the list of edges into a number representing the permutation of the edges.
-     * @param edges   edges representation (ori << 3 + perm)
+     * @param edges   edges representation (ori &lt;&lt; 3 + perm)
      * @return        an integer between 0 and 719 representing the permutation of 6 elements
      */
     public static int packEdgePerm(int[] edges) {
@@ -111,7 +111,7 @@ public class PyraminxSolver {
 
     /**
      * Converts the list of edges into a number representing the orientation of the edges.
-     * @param edges    edges representation (ori << 3 + perm)
+     * @param edges    edges representation (ori &lt;&lt; 3 + perm)
      * @return         an integer between 0 and 31 representing the orientation of 5 elements (the 6th is fixed)
      */
     public static int packEdgeOrient(int[] edges) {

--- a/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/TwoByTwoSolver.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/TwoByTwoSolver.java
@@ -42,7 +42,7 @@ public class TwoByTwoSolver {
 
     /**
      * Converts the list of cubies into a number representing the permutation of the cubies.
-     * @param cubies   cubies representation (ori << 3 + perm)
+     * @param cubies   cubies representation (ori &lt;&lt; 3 + perm)
      * @return         an integer between 0 and 5039 representing the permutation of 7 elements
      */
     public static int packPerm(int[] cubies){
@@ -59,7 +59,7 @@ public class TwoByTwoSolver {
     /**
      * Converts an integer representing a permutation of 7 elements into a list of cubies.
      * @param perm     an integer between 0 and 5039 representing the permutation of 7 elements
-     * @param cubies   cubies representation (ori << 3 + perm)
+     * @param cubies   cubies representation (ori &lt;&lt; 3 + perm)
      */
     public static void unpackPerm(int perm, int[] cubies){
         int val = 0x6543210;
@@ -77,7 +77,7 @@ public class TwoByTwoSolver {
 
     /**
      * Converts the list of cubies into a number representing the orientation of the cubies.
-     * @param cubies   cubies representation (ori << 3 + perm)
+     * @param cubies   cubies representation (ori &lt;&lt; 3 + perm)
      * @return         an integer between 0 and 728 representing the orientation of 6 elements (the 7th is fixed)
      */
     public static int packOrient(int[] cubies){
@@ -91,7 +91,7 @@ public class TwoByTwoSolver {
     /**
      * Converts an integer representing the orientation of 6 elements into a list of cubies.
      * @param ori      an integer between 0 and 728 representing the orientation of 6 elements (the 7th is fixed)
-     * @param cubies   cubies representation (ori << 3 + perm)
+     * @param cubies   cubies representation (ori &lt;&lt; 3 + perm)
      */
     public static void unpackOrient(int ori, int[] cubies){
         int sum_ori = 0;

--- a/scrambles/src/main/java/net/gnehzr/tnoodle/scrambles/Puzzle.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/scrambles/Puzzle.java
@@ -25,7 +25,7 @@ import static java.lang.Math.ceil;
 
 /**
  * Puzzle and TwistyPuzzle encapsulate all the information to filter out
- * scrambles <= wcaMinScrambleDistance (defaults to 1)
+ * scrambles &lt;= wcaMinScrambleDistance (defaults to 1)
  * move away from solved (see generateWcaScramble),
  * and to generate random turn scrambles generically (see generateRandomMoves).
  *
@@ -310,7 +310,7 @@ public abstract class Puzzle implements Exportable {
         public int compareTo(Bucket<H> other) {
             return this.value - other.value;
         }
-        
+
         public int hashCode() {
             return this.value;
         }
@@ -443,7 +443,7 @@ public abstract class Puzzle implements Exportable {
                 fringeComparing = fringeSolved;
                 minComparingFringe = minFringeSolved;
             }
-            
+
             PuzzleState node = fringeExtending.pop();
             int distance = seenExtending.get(node);
             if(seenComparing.containsKey(node)) {
@@ -558,7 +558,7 @@ public abstract class Puzzle implements Exportable {
         }
 
         // Step 3: solved <----- bestIntersection
-        
+
         int distanceFromSolved = seenSolved.get(state.getNormalized());
     outer:
         while(distanceFromSolved > 0) {

--- a/scrambles/src/main/java/net/gnehzr/tnoodle/scrambles/Puzzle.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/scrambles/Puzzle.java
@@ -71,6 +71,8 @@ public abstract class Puzzle implements Exportable {
     /**
      * Returns the minimum distance from solved that any scramble this Puzzle
      * generates will be.
+     *
+     * @return The integer representing the exact minimum scramble distance
      */
     public int getWcaMinScrambleDistance() {
         return wcaMinScrambleDistance;
@@ -130,7 +132,12 @@ public abstract class Puzzle implements Exportable {
         return generateScrambles(r, count);
     }
 
-    /** seeded scrambles, these can't be cached, so they'll be a little slower **/
+    /**
+     * seeded scrambles, these can't be cached, so they'll be a little slower
+     *
+     * @param seed The seed to be used for generating this scramble
+     * @return A scramble similar to {@link #generateScramble}, except that it is guaranteed to be based on {@code seed}
+     */
     @Export
     public final String generateSeededScramble(String seed) {
         return generateSeededScramble(seed.getBytes());
@@ -172,7 +179,7 @@ public abstract class Puzzle implements Exportable {
 
     /**
      * TODO - document! alphabetical
-     * @return
+     * @return TODO, see above
      */
     @Export
     public String[] getFaceNames() {
@@ -183,8 +190,8 @@ public abstract class Puzzle implements Exportable {
 
     /**
      * TODO - document!
-     * @param scheme
-     * @return
+     * @param scheme TODO, see above
+     * @return TODO, see above
      */
     public HashMap<String, Color> parseColorScheme(String scheme) {
         HashMap<String, Color> colorScheme = getDefaultColorScheme();
@@ -225,6 +232,7 @@ public abstract class Puzzle implements Exportable {
      * @param colorScheme A HashMap mapping face names to Colors.
      *          Any missing entries will be merged with the defaults from getDefaultColorScheme().
      *          If null, just the defaults are used.
+     * @return An SVG object representing the drawn scramble.
      * @throws InvalidScrambleException If scramble is invalid.
      */
     public Svg drawScramble(String scramble, HashMap<String, Color> colorScheme) throws InvalidScrambleException {
@@ -593,7 +601,7 @@ public abstract class Puzzle implements Exportable {
          *
          * @param algorithm A space separated String of moves to apply to state
          * @return The resulting PuzzleState
-         * @throws InvalidScrambleException
+         * @throws InvalidScrambleException If the scramble is invalid, for example if it uses invalid notation.
          */
         public PuzzleState applyAlgorithm(String algorithm) throws InvalidScrambleException {
             PuzzleState state = this;
@@ -673,7 +681,7 @@ public abstract class Puzzle implements Exportable {
          * puzzles. For example, square one may wish to declare (3,3) as 1
          * move. Another possible use for this would be rotations, which
          * count as 0 moves.
-         * @param move
+         * @param move The move for which to compute costs
          * @return The cost of doing this move.
          */
         public int getMoveCost(String move) {
@@ -734,7 +742,7 @@ public abstract class Puzzle implements Exportable {
          * Returns true if this state is equal to other.
          * Note that a puzzle like 4x4 must compare all orientations of the puzzle, otherwise
          * generateRandomMoves() will allow for trivial sequences of turns like Lw Rw'.
-         * @param other
+         * @param other The other object to check for equality
          * @return true if this is equal to other
          */
         public abstract boolean equals(Object other);
@@ -749,6 +757,7 @@ public abstract class Puzzle implements Exportable {
          * NOTE: It is assumed that this method is thread safe! That means unless you know what you're doing,
          * use the synchronized keyword when implementing this method:<br>
          * <code>protected synchronized void drawScramble();</code>
+         * @param colorScheme The color scheme to use while drawing
          * @return An Svg instance representing this scramble.
          */
         protected abstract Svg drawScramble(HashMap<String, Color> colorScheme);


### PR DESCRIPTION
The current working state of TNoodle doesn't compile because our javadoc contains some invalid HTML character usage.

This is only becoming a problem now because Gradle < 6 was less strict in enforcing these rules.

Purely cosmetical changes, so merging them in as soon as Travis says Yes