### PR TITLE
Clearly distinguish clock pin positions in SVG

### DIFF
--- a/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/ClockPuzzle.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/puzzle/ClockPuzzle.java
@@ -1,11 +1,7 @@
 package net.gnehzr.tnoodle.puzzle;
 
-import net.gnehzr.tnoodle.svglite.Color;
-import net.gnehzr.tnoodle.svglite.Dimension;
-import net.gnehzr.tnoodle.svglite.Circle;
-import net.gnehzr.tnoodle.svglite.Path;
-import net.gnehzr.tnoodle.svglite.Svg;
-import net.gnehzr.tnoodle.svglite.Transform;
+import net.gnehzr.tnoodle.svglite.*;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -32,6 +28,7 @@ public class ClockPuzzle extends Puzzle {
     private static final int arrowHeight = 10;
     private static final int arrowRadius = 2;
     private static final int pinRadius = 4;
+    private static final int pinUpOffset = 6;
     private static final double arrowAngle = Math.PI / 2 - Math.acos( (double)arrowRadius / (double)arrowHeight );
 
     private static final int gap = 5;
@@ -257,7 +254,7 @@ public class ClockPuzzle extends Puzzle {
                     for(int j = -1; j <= 1; j++) {
                         Transform tCopy = new Transform(t);
                         tCopy.translate(2*i*clockOuterRadius, 2*j*clockOuterRadius);
-                        
+
                         Circle clockFace = new Circle(0, 0, clockRadius);
                         clockFace.setStroke(Color.BLACK);
                         clockFace.setFill(colorScheme.get(colorString[s]+ "Clock"));
@@ -362,6 +359,50 @@ public class ClockPuzzle extends Puzzle {
             pin.setStroke(Color.BLACK);
             pin.setFill(colorScheme.get( pinUp ? "PinUp" : "PinDown" ));
             g.appendChild(pin);
+
+            // there have been problems in the past with clock pin states being "inverted",
+            // see https://github.com/thewca/tnoodle/issues/423 for details.
+            if (pinUp) {
+                Transform bodyTransform = new Transform(t);
+                // pin circle transform relates to the circle *center*. Since it is two
+                // radii wide, we only move *one* radius to the right.
+                bodyTransform.translate(-pinRadius, -pinUpOffset);
+
+                Rectangle cylinderBody = new Rectangle(0, 0, 2 * pinRadius, pinUpOffset);
+                cylinderBody.setTransform(bodyTransform);
+                cylinderBody.setStroke(null);
+                cylinderBody.setFill(colorScheme.get( "PinUp" ));
+                g.appendChild(cylinderBody);
+
+                // We are NOT using the rectangle stroke, because those border strokes would cross through
+                // the bottom circle (ie cylinder "foot"). Drawing paths left and right is less cumbersome
+                // than drawing a stroked rectangle and overlaying it yet again with a stroke-less circle
+                Path cylinderWalls = new Path();
+
+                // left border
+                cylinderWalls.moveTo(0, 0);
+                cylinderWalls.lineTo(0, pinUpOffset);
+
+                // right border
+                cylinderWalls.moveTo(2 * pinRadius, 0);
+                cylinderWalls.lineTo(2 * pinRadius, pinUpOffset);
+
+                cylinderWalls.closePath();
+                cylinderWalls.setStroke(Color.BLACK);
+                cylinderWalls.setTransform(bodyTransform);
+                g.appendChild(cylinderWalls);
+
+                // Cylinder top "lid". Basically just a second pin circle
+                // that is lifted `pinRadius` pixels high.
+                Transform headTransform = new Transform(t);
+                headTransform.translate(0, -pinUpOffset);
+
+                Circle cylinderHead = new Circle(0, 0, pinRadius);
+                cylinderHead.setTransform(headTransform);
+                cylinderHead.setStroke(Color.BLACK);
+                cylinderHead.setFill(colorScheme.get( "PinUp" ));
+                g.appendChild(cylinderHead);
+            }
         }
 
     }


### PR DESCRIPTION
Fixes #423

Basically fakes the impression of a cylinder by stacking "bottom circle" + "body rectangle" + "top lid circle" on top of each other.

## FAQ
Q: Why not use "circle-rectangle-circle" alone? Why the additional path strokes?
A: See source code comments. Adding strokes to the central cylinder would also cross the bottom "cylinder foot" circle, and that would require yet another overlay circle.

Q: Where do you define the height of the pin?
A: Constant `int` at the top of the `ClockPuzzle` class, called `pinUpOffset`. The concrete value `6` just occured to me as a good approximation of Lucas' mockup in the original issue.

Q: Wait, you're saying clock pins are important?!
A: This PR is **not** a political statement in the 2020 Regulation Updates debate. I am merely trying to check off issues, any further implications would be purely coincidental.