### PR TITLE
Move PuzzlePlugins to server package

### DIFF
--- a/scrambles/build.gradle.kts
+++ b/scrambles/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     `java-library`
     checkstyle
     `maven-publish`
-    kotlin("jvm")
 }
 
 configureJava()
@@ -30,13 +29,7 @@ dependencies {
     implementation(project(":threephase"))
     implementation(project(":sq12phase"))
 
-    implementation(kotlin("stdlib-jdk8"))
-
     api(GWTEXPORTER)
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = KOTLIN_JVM_TARGET
 }
 
 configureJUnit5()

--- a/scrambles/src/test/java/net/gnehzr/tnoodle/HugeScrambleTest.java
+++ b/scrambles/src/test/java/net/gnehzr/tnoodle/HugeScrambleTest.java
@@ -7,10 +7,9 @@ import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.SortedMap;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
-import kotlin.Lazy;
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins;
 import net.gnehzr.tnoodle.scrambles.AlgorithmBuilder;
 import net.gnehzr.tnoodle.scrambles.AlgorithmBuilder.MergingMode;
 import net.gnehzr.tnoodle.scrambles.InvalidMoveException;
@@ -38,9 +37,9 @@ import org.timepedia.exporter.client.Exportable;
 
 public class HugeScrambleTest {
     private static final Logger l = Logger.getLogger(HugeScrambleTest.class.getName());
-    
+
     private static final Random r = Puzzle.getSecureRandom();
-    
+
     static class LockHolder extends Thread {
         public LockHolder() {
             setDaemon(true);
@@ -84,10 +83,10 @@ public class HugeScrambleTest {
 
         int SCRAMBLE_COUNT = 10;
 
-        SortedMap<String, Lazy<Puzzle>> lazyScramblers = PuzzlePlugins.INSTANCE.getPUZZLES();
+        SortedMap<String, Supplier<Puzzle>> lazyScramblers = TestPuzzles.getTestablePuzzles();
         for(String puzzle : lazyScramblers.keySet()) {
-            Lazy<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
-            final Puzzle scrambler = lazyScrambler.getValue();
+            Supplier<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
+            final Puzzle scrambler = lazyScrambler.get();
             for(int count = 0; count < SCRAMBLE_COUNT; count++){
                 PuzzleState state = scrambler.getSolvedState().applyAlgorithm(scrambler.generateWcaScramble(r));
                 assertSame(state.solveIn(scrambler.getWcaMinScrambleDistance() - 1), null);
@@ -100,14 +99,14 @@ public class HugeScrambleTest {
         int SCRAMBLE_COUNT = 10;
         int SCRAMBLE_LENGTH = 4;
 
-        SortedMap<String, Lazy<Puzzle>> lazyScramblers = PuzzlePlugins.INSTANCE.getPUZZLES();
+        SortedMap<String, Supplier<Puzzle>> lazyScramblers = TestPuzzles.getTestablePuzzles();
 
         for(String puzzle : lazyScramblers.keySet()) {
-            Lazy<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
-            final Puzzle scrambler = lazyScrambler.getValue();
+            Supplier<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
+            final Puzzle scrambler = lazyScrambler.get();
 
             System.out.println("Testing " + puzzle);
-            
+
             // Test solving the solved state
             String solution = scrambler.getSolvedState().solveIn(0);
             assertEquals("", solution);
@@ -138,11 +137,11 @@ public class HugeScrambleTest {
         int SCRAMBLE_COUNT = 10;
         boolean drawScramble = true;
 
-        SortedMap<String, Lazy<Puzzle>> lazyScramblers = PuzzlePlugins.INSTANCE.getPUZZLES();
+        SortedMap<String, Supplier<Puzzle>> lazyScramblers = TestPuzzles.getTestablePuzzles();
 
         for(String puzzle : lazyScramblers.keySet()) {
-            Lazy<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
-            final Puzzle scrambler = lazyScrambler.getValue();
+            Supplier<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
+            final Puzzle scrambler = lazyScrambler.get();
 
             System.out.println("Testing " + puzzle);
 
@@ -194,17 +193,15 @@ public class HugeScrambleTest {
 
     @Test
     public void testNames() {
-        SortedMap<String, Lazy<Puzzle>> lazyScramblers = PuzzlePlugins.INSTANCE.getPUZZLES();
+        SortedMap<String, Supplier<Puzzle>> lazyScramblers = TestPuzzles.getTestablePuzzles();
 
         // Check that the names by which the scramblers refer to themselves
         // is the same as the names by which we refer to them in the plugin definitions file.
         for(String shortName : lazyScramblers.keySet()) {
-            String longName = PuzzlePlugins.INSTANCE.getScramblerLongName(shortName);
-            Lazy<Puzzle> lazyScrambler = lazyScramblers.get(shortName);
-            Puzzle scrambler = lazyScrambler.getValue();
-            
+            Supplier<Puzzle> lazyScrambler = lazyScramblers.get(shortName);
+            Puzzle scrambler = lazyScrambler.get();
+
             assertEquals(shortName, scrambler.getShortName());
-            assertEquals(longName, scrambler.getLongName());
 
             System.out.println(Exportable.class + " isAssignableFrom " + scrambler.getClass());
             assertTrue(Exportable.class.isAssignableFrom(scrambler.getClass()));
@@ -232,7 +229,7 @@ public class HugeScrambleTest {
             System.out.println(solution);
         }
     }
-    
+
     @Test
     public void testCubePuzzle() throws InvalidScrambleException, InvalidMoveException {
         testCubeNormalization();
@@ -250,11 +247,11 @@ public class HugeScrambleTest {
         CubeState normalizedSolvedState = solved.getNormalized();
         assertEquals(normalizedState, normalizedSolvedState);
         assertEquals(normalizedState.hashCode(), normalizedSolvedState.hashCode());
-        
+
         state = (CubeState) solved.applyAlgorithm("Uw Dw'");
         normalizedState = state.getNormalized();
         assertEquals(normalizedState, normalizedSolvedState);
-        
+
         CubePuzzle threes = new ThreeByThreeCubePuzzle();
 
         solved = threes.getSolvedState();
@@ -266,7 +263,7 @@ public class HugeScrambleTest {
         String alg = "D2 U' L2 B2 F2 D B2 U' B2 F D' F U' R F2 L2 D' B D F'";
         ab3.appendAlgorithm(alg);
         assertEquals(ab3.toString(), alg);
-        
+
         for(int depth = 0; depth < 100; depth++) {
             state = Puzzle.choose(r, state.getSuccessorsByName().values());
             normalizedState = state.getNormalized();
@@ -294,7 +291,7 @@ public class HugeScrambleTest {
         abSq1 = new AlgorithmBuilder(sq1, MergingMode.CANONICALIZE_MOVES);
         abSq1.appendAlgorithm("(1,0) (0,1)");
         assertEquals(abSq1.toString(), "(1,1)");
-        
+
         abSq1 = new AlgorithmBuilder(sq1, MergingMode.CANONICALIZE_MOVES);
         abSq1.appendAlgorithm("(0,1) (1,1)");
         assertEquals(abSq1.toString(), "(1,2)");
@@ -422,12 +419,12 @@ public class HugeScrambleTest {
 
         // How long does it takes to test if a puzzle is solvable in <= 1 move?
         int SCRAMBLE_COUNT = 100;
-        SortedMap<String, Lazy<Puzzle>> lazyScramblers = PuzzlePlugins.INSTANCE.getPUZZLES();
-        
+        SortedMap<String, Supplier<Puzzle>> lazyScramblers = TestPuzzles.getTestablePuzzles();
+
         for(String puzzle : lazyScramblers.keySet()) {
-            Lazy<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
-            final Puzzle scrambler = lazyScrambler.getValue();
-            
+            Supplier<Puzzle> lazyScrambler = lazyScramblers.get(puzzle);
+            final Puzzle scrambler = lazyScrambler.get();
+
             l.info("Are " + THREE_BY_THREE_SCRAMBLE_COUNT + " " + puzzle + " more than one move away from solved?");
             startMillis = System.currentTimeMillis();
             PuzzleState solved = scrambler.getSolvedState();

--- a/scrambles/src/test/java/net/gnehzr/tnoodle/TestPuzzles.java
+++ b/scrambles/src/test/java/net/gnehzr/tnoodle/TestPuzzles.java
@@ -1,0 +1,39 @@
+package net.gnehzr.tnoodle;
+
+import net.gnehzr.tnoodle.puzzle.*;
+import net.gnehzr.tnoodle.scrambles.Puzzle;
+import net.gnehzr.tnoodle.util.LazySupplier;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+public class TestPuzzles {
+    private static final Map<String, Supplier<Puzzle>> TESTABLE_PUZZLES = new HashMap<>();
+
+    static {
+        TESTABLE_PUZZLES.put("222", new LazySupplier<>(TwoByTwoCubePuzzle::new));
+        TESTABLE_PUZZLES.put("333", new LazySupplier<>(ThreeByThreeCubePuzzle::new));
+        TESTABLE_PUZZLES.put("444", new LazySupplier<>(FourByFourCubePuzzle::new));
+        TESTABLE_PUZZLES.put("444fast", new LazySupplier<>(FourByFourRandomTurnsCubePuzzle::new));
+        TESTABLE_PUZZLES.put("555", new LazySupplier<>(() -> new CubePuzzle(5)));
+        TESTABLE_PUZZLES.put("666", new LazySupplier<>(() -> new CubePuzzle(6)));
+        TESTABLE_PUZZLES.put("777", new LazySupplier<>(() -> new CubePuzzle(7)));
+        TESTABLE_PUZZLES.put("333ni", new LazySupplier<>(NoInspectionThreeByThreeCubePuzzle::new));
+        TESTABLE_PUZZLES.put("444ni", new LazySupplier<>(NoInspectionFourByFourCubePuzzle::new));
+        TESTABLE_PUZZLES.put("555ni", new LazySupplier<>(NoInspectionFiveByFiveCubePuzzle::new));
+        TESTABLE_PUZZLES.put("333fm", new LazySupplier<>(ThreeByThreeCubeFewestMovesPuzzle::new));
+        TESTABLE_PUZZLES.put("pyram", new LazySupplier<>(PyraminxPuzzle::new));
+        TESTABLE_PUZZLES.put("sq1", new LazySupplier<>(SquareOnePuzzle::new));
+        TESTABLE_PUZZLES.put("sq1fast", new LazySupplier<>(SquareOneUnfilteredPuzzle::new));
+        TESTABLE_PUZZLES.put("minx", new LazySupplier<>(MegaminxPuzzle::new));
+        TESTABLE_PUZZLES.put("clock", new LazySupplier<>(ClockPuzzle::new));
+        TESTABLE_PUZZLES.put("skewb", new LazySupplier<>(SkewbPuzzle::new));
+    }
+
+    public static SortedMap<String, Supplier<Puzzle>> getTestablePuzzles() {
+        return new TreeMap<>(TESTABLE_PUZZLES);
+    }
+}

--- a/scrambles/src/test/java/net/gnehzr/tnoodle/scrambles/AlgorithmBuilderTest.java
+++ b/scrambles/src/test/java/net/gnehzr/tnoodle/scrambles/AlgorithmBuilderTest.java
@@ -1,14 +1,13 @@
 package net.gnehzr.tnoodle.scrambles;
 
-import kotlin.Lazy;
-
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins;
+import net.gnehzr.tnoodle.TestPuzzles;
 import net.gnehzr.tnoodle.puzzle.CubePuzzle;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -25,11 +24,11 @@ public class AlgorithmBuilderTest {
         assertFalse(moves.contains("3Lw"));
         assertFalse(moves.contains("3Dw"));
 
-        Map<String, Lazy<Puzzle>> lazyScramblers = PuzzlePlugins.INSTANCE.getPUZZLES();
+        Map<String, Supplier<Puzzle>> lazyScramblers = TestPuzzles.getTestablePuzzles();
 
-        for (Map.Entry<String, Lazy<Puzzle>> lazyEntry : lazyScramblers.entrySet()) {
+        for (Map.Entry<String, Supplier<Puzzle>> lazyEntry : lazyScramblers.entrySet()) {
             String puzzle = lazyEntry.getKey();
-            Puzzle scrambler = lazyEntry.getValue().getValue();
+            Puzzle scrambler = lazyEntry.getValue().get();
 
             System.out.println("Testing redundant moves on " + puzzle);
 

--- a/scrambles/src/test/java/net/gnehzr/tnoodle/util/LazySupplier.java
+++ b/scrambles/src/test/java/net/gnehzr/tnoodle/util/LazySupplier.java
@@ -1,0 +1,22 @@
+package net.gnehzr.tnoodle.util;
+
+import java.util.function.Supplier;
+
+public class LazySupplier<T> implements Supplier<T> {
+    private final Supplier<T> originalSupplier;
+
+    public LazySupplier(Supplier<T> supply) {
+        this.originalSupplier = supply;
+    }
+
+    private T cache = null;
+
+    @Override
+    public T get() {
+        if (this.cache == null) {
+            this.cache = originalSupplier.get();
+        }
+
+        return this.cache;
+    }
+}

--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/Plugins.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/Plugins.kt
@@ -1,4 +1,4 @@
-package net.gnehzr.tnoodle.plugins
+package org.worldcubeassociation.tnoodle.server
 
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/PuzzlePlugins.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/PuzzlePlugins.kt
@@ -1,7 +1,8 @@
-package net.gnehzr.tnoodle.plugins
+package org.worldcubeassociation.tnoodle.server.webscrambles
 
 import net.gnehzr.tnoodle.puzzle.*
 import net.gnehzr.tnoodle.scrambles.Puzzle
+import org.worldcubeassociation.tnoodle.server.Plugins
 import java.util.*
 
 object PuzzlePlugins {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
@@ -1,6 +1,5 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles
 
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins
 import net.gnehzr.tnoodle.puzzle.ThreeByThreeCubePuzzle
 import net.gnehzr.tnoodle.scrambles.Puzzle
 import net.gnehzr.tnoodle.scrambles.ScrambleCacher

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/gson/Puzzlerizer.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/gson/Puzzlerizer.kt
@@ -2,7 +2,7 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.gson
 
 import com.google.gson.*
 import net.gnehzr.tnoodle.scrambles.Puzzle
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins
+import org.worldcubeassociation.tnoodle.server.webscrambles.PuzzlePlugins
 import java.lang.reflect.Type
 
 class Puzzlerizer : JsonSerializer<Puzzle>, JsonDeserializer<Puzzle> {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/PuzzleListHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/PuzzleListHandler.kt
@@ -7,8 +7,8 @@ import io.ktor.routing.Routing
 import io.ktor.routing.get
 import net.gnehzr.tnoodle.scrambles.Puzzle
 import org.worldcubeassociation.tnoodle.server.RouteHandler
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins
 import org.worldcubeassociation.tnoodle.server.RouteHandler.Companion.splitNameAndExtension
+import org.worldcubeassociation.tnoodle.server.webscrambles.PuzzlePlugins
 
 object PuzzleListHandler : RouteHandler {
     private val puzzleInfoByShortName: Map<String, Map<String, String>>

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ReadmeHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ReadmeHandler.kt
@@ -8,7 +8,7 @@ import io.ktor.routing.get
 import io.ktor.routing.route
 import org.worldcubeassociation.tnoodle.server.RouteHandler
 import org.worldcubeassociation.tnoodle.server.RouteHandler.Companion.markdownToHTML
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins
+import org.worldcubeassociation.tnoodle.server.webscrambles.PuzzlePlugins
 
 object ReadmeHandler : RouteHandler {
     private val scramblers = PuzzlePlugins.PUZZLES

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ScrambleViewHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ScrambleViewHandler.kt
@@ -23,9 +23,9 @@ import org.apache.batik.util.SVGConstants
 import org.worldcubeassociation.tnoodle.server.RouteHandler
 import org.worldcubeassociation.tnoodle.server.RouteHandler.Companion.parseQuery
 import org.worldcubeassociation.tnoodle.server.util.GsonUtil.GSON
-import net.gnehzr.tnoodle.plugins.PuzzlePlugins
 import org.worldcubeassociation.tnoodle.server.RouteHandler.Companion.splitNameAndExtension
 import org.worldcubeassociation.tnoodle.server.util.ServerEnvironmentConfig
+import org.worldcubeassociation.tnoodle.server.webscrambles.PuzzlePlugins
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper
 import java.awt.image.BufferedImage


### PR DESCRIPTION
We use `PuzzlePlugins` to lazily provide puzzle instances that behave like singletons to the `webscrambles` server.

There is no reason why the `:scrambles` code (which is subject to be refactored into `tnoodle-lib`) should know these plugins. Also, changing this gets rid of the entire Kotlin dependency of the `:scrambles` module (for now, I'd rather migrate to Kotlin all at once).

The only reasonable alternative would be to move PuzzlePlugins back to Java entirely, but I currently don't see any reason why this would be necessary. Please advise.