### PR TITLE
Add Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 .idea/
 local.properties
 TNoodle-WCA-*.jar
+TNoodle-Docker-*.jar
 tnoodle_resources/
 tnoodle_pruning_cache/
 **/logging/*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# We select the base image from. Locally available or from https://hub.docker.com/
+FROM openjdk:8-jre-alpine
+
+# We define the user we will use in this instance to prevent using root that even in a container, can be a security risk.
+ENV APPLICATION_USER ktor
+
+# Then we add the user, create the /app folder and give permissions to our user.
+RUN adduser -D -g '' $APPLICATION_USER
+RUN mkdir /app
+RUN chown -R $APPLICATION_USER /app
+
+# Marks this container to use the specified $APPLICATION_USER
+USER $APPLICATION_USER
+
+# We copy the FAT Jar we built into the /app folder and sets that folder as the working directory.
+COPY ./webscrambles/build/libs/webscrambles-0.15.0-all.jar /app/tnoodle-application.jar
+WORKDIR /app
+
+# We launch java to execute the jar, with good defauls intended for containers.
+CMD ["java", "-server", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-XX:InitialRAMFraction=2", "-XX:MinRAMFraction=2", "-XX:MaxRAMFraction=2", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=100", "-XX:+UseStringDeduplication", "-jar", "tnoodle-application.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN chown -R $APPLICATION_USER /app
 USER $APPLICATION_USER
 
 # We copy the FAT Jar we built into the /app folder and sets that folder as the working directory.
-COPY ./webscrambles/build/libs/webscrambles-0.15.0-all.jar /app/tnoodle-application.jar
+COPY ./TNoodle-Docker-latest.jar /app/tnoodle-application.jar
 WORKDIR /app
 
 # We launch java to execute the jar, with good defauls intended for containers.

--- a/buildSrc/src/main/kotlin/configurations/FileUtils.kt
+++ b/buildSrc/src/main/kotlin/configurations/FileUtils.kt
@@ -1,0 +1,11 @@
+package configurations
+
+import org.gradle.api.Project
+import java.io.File
+import java.nio.file.Files
+
+object FileUtils {
+    fun Project.symlink(linkName: File, originFile: File) {
+        Files.createSymbolicLink(linkName.toPath(), originFile.toPath())
+    }
+}

--- a/webscrambles/build.gradle.kts
+++ b/webscrambles/build.gradle.kts
@@ -1,4 +1,5 @@
 import configurations.CompilerSettings.KOTLIN_JVM_TARGET
+import configurations.FileUtils.symlink
 import configurations.Frameworks.configureJUnit5
 import configurations.Languages.attachRemoteRepositories
 import configurations.ProjectVersions.gitVersionTag
@@ -104,5 +105,17 @@ tasks.create("registerManifest") {
                 )
             }
         }
+    }
+}
+
+tasks.getByName("shadowJar") {
+    doLast {
+        val targetProject = project.name
+
+        val originFile = file("$buildDir/libs/$targetProject-$version-all.jar")
+        val targetLn = rootProject.file("TNoodle-Docker-latest.jar")
+            .also { if (it.exists()) it.delete() }
+
+        symlink(targetLn, originFile)
     }
 }


### PR DESCRIPTION
Just in case we may need one in the future. This allows TNoodle to run inside an isolated Docker container, including the RESTful API exposed by `:webscrambles`.