### PR TITLE
Intentionally downgrade ZIP encryption algorithm

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
@@ -168,7 +168,7 @@ data class ScrambleRequest(
 
             if (useEncryption) {
                 isEncryptFiles = true
-                encryptionMethod = EncryptionMethod.AES
+                encryptionMethod = EncryptionMethod.ZIP_STANDARD
             }
         }
 


### PR DESCRIPTION
With the newer version of the Java ZIP library we're using, we *technically* have the option to use strong AES encryption (cf. https://github.com/thewca/tnoodle/issues/198)

However, since the AES ZIP encryption algorithm was only retroactively added to the ZIP standard, many standard archiving libraries don't support it. Most notably, the native archive viewer on macOS as well as the `tar` CLI on Linux do **not** support AES.
You can always view the files (as the file headers in ZIP are unencrypted by definition) but you have to install third-party software to actually access their *content*.

Going forward, we have two options:
1. Use stronger AES encryption, thereby implicitly forcing Delegates to download and install third-party archiving tools such as 7zip that support extracting AES-encrypted ZIP files
2. Intentionally downgrade and accept the shortcomings of the weaker ZIP algorithm

Does anybody have favo(u)rable arguments for either option? I tend towards 2. as I'd like to keep the dependencies to run and use TNoodle at a bare minimum.