### PR TITLE
Use correct SimpleDateFormat for PDF watermarking

### DIFF
--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/WebServerUtils.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/WebServerUtils.kt
@@ -5,10 +5,11 @@ import java.net.URISyntaxException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
 import java.util.Random
 
 object WebServerUtils {
-    val SDF = SimpleDateFormat("yyyy-MM-dd")
+    val DTF = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
     val PRUNING_FOLDER = "tnoodle_pruning_cache"
     val DEVEL_VERSION = "devel-TEMP"

--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/WebServerUtils.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/WebServerUtils.kt
@@ -8,7 +8,7 @@ import java.text.SimpleDateFormat
 import java.util.Random
 
 object WebServerUtils {
-    val SDF = SimpleDateFormat("YYYY-mm-dd")
+    val SDF = SimpleDateFormat("yyyy-MM-dd")
 
     val PRUNING_FOLDER = "tnoodle_pruning_cache"
     val DEVEL_VERSION = "devel-TEMP"

--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/WebServerUtils.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/WebServerUtils.kt
@@ -9,8 +9,6 @@ import java.time.format.DateTimeFormatter
 import java.util.Random
 
 object WebServerUtils {
-    val DTF = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-
     val PRUNING_FOLDER = "tnoodle_pruning_cache"
     val DEVEL_VERSION = "devel-TEMP"
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
@@ -17,6 +17,7 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.OrderedScramble
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper
 import java.io.ByteArrayOutputStream
 import java.net.URLDecoder
+import java.time.LocalDate
 import java.util.*
 import kotlin.math.min
 import net.gnehzr.tnoodle.svglite.Color as SVGColor
@@ -120,7 +121,7 @@ data class ScrambleRequest(
             }
         }
 
-        fun ScrambleRequest.createPdf(globalTitle: String?, creationDate: Date, versionTag: String, locale: Locale): PdfContent {
+        fun ScrambleRequest.createPdf(globalTitle: String?, creationDate: LocalDate, versionTag: String, locale: Locale): PdfContent {
             // 333mbf is handled pretty specially: each "scramble" is actually a newline separated
             // list of 333ni scrambles.
             // If we detect that we're dealing with 333mbf, then we will generate 1 sheet per attempt,
@@ -193,7 +194,7 @@ data class ScrambleRequest(
 
         private val PDF_CACHE = mutableMapOf<ScrambleRequest, PdfContent>()
 
-        fun requestsToZip(globalTitle: String?, generationDate: Date, versionTag: String, scrambleRequests: List<ScrambleRequest>, password: String?, generationUrl: String?, wcifHelper: WCIFHelper?): ByteArrayOutputStream {
+        fun requestsToZip(globalTitle: String?, generationDate: LocalDate, versionTag: String, scrambleRequests: List<ScrambleRequest>, password: String?, generationUrl: String?, wcifHelper: WCIFHelper?): ByteArrayOutputStream {
             val baosZip = ByteArrayOutputStream()
 
             val usePassword = password != null
@@ -337,7 +338,7 @@ data class ScrambleRequest(
             return baosZip
         }
 
-        fun requestsToCompletePdf(globalTitle: String?, generationDate: Date, versionTag: String, scrambleRequests: List<ScrambleRequest>): PdfContent {
+        fun requestsToCompletePdf(globalTitle: String?, generationDate: LocalDate, versionTag: String, scrambleRequests: List<ScrambleRequest>): PdfContent {
             val originalPdfs = scrambleRequests.map {
                 PDF_CACHE.getOrPut(it) { it.createPdf(globalTitle, generationDate, versionTag, Translate.DEFAULT_LOCALE) }
             }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
@@ -29,7 +29,7 @@ class WatermarkPdfWrapper(val original: PdfContent, val creationTitle: String, v
 
             // Header
             ColumnText.showTextAligned(cb,
-                Element.ALIGN_LEFT, Phrase(creationDate.format(WebServerUtils.DTF)),
+                Element.ALIGN_LEFT, Phrase(creationDate.toString()),
                 rect.left, rect.top, 0f)
 
             ColumnText.showTextAligned(cb,

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
@@ -8,9 +8,9 @@ import com.itextpdf.text.pdf.PdfReader
 import com.itextpdf.text.pdf.PdfWriter
 import org.worldcubeassociation.tnoodle.server.util.WebServerUtils
 import java.io.ByteArrayOutputStream
-import java.util.*
+import java.time.LocalDate
 
-class WatermarkPdfWrapper(val original: PdfContent, val creationTitle: String, val creationDate: Date, val versionTag: String, globalTitle: String?) : BasePdfSheet<PdfWriter>(globalTitle) {
+class WatermarkPdfWrapper(val original: PdfContent, val creationTitle: String, val creationDate: LocalDate, val versionTag: String, globalTitle: String?) : BasePdfSheet<PdfWriter>(globalTitle) {
     override val document = Document(PAGE_SIZE, 0f, 0f, 75f, 75f)
 
     override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfWriter = PdfWriter.getInstance(document, bytes)
@@ -29,7 +29,7 @@ class WatermarkPdfWrapper(val original: PdfContent, val creationTitle: String, v
 
             // Header
             ColumnText.showTextAligned(cb,
-                Element.ALIGN_LEFT, Phrase(WebServerUtils.SDF.format(creationDate)),
+                Element.ALIGN_LEFT, Phrase(creationDate.format(WebServerUtils.DTF)),
                 rect.left, rect.top, 0f)
 
             ColumnText.showTextAligned(cb,

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ScrambleHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ScrambleHandler.kt
@@ -15,15 +15,14 @@ import org.worldcubeassociation.tnoodle.server.RouteHandler.Companion.splitNameA
 import org.worldcubeassociation.tnoodle.server.util.ServerEnvironmentConfig
 import org.worldcubeassociation.tnoodle.server.webscrambles.InvalidScrambleRequestException
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
-
-import java.util.Date
+import java.time.LocalDate
 
 class ScrambleHandler(val environmentConfig: ServerEnvironmentConfig) : RouteHandler {
     override fun install(router: Routing) {
         router.get("/scramble/{filename}") {
             val filename = call.parameters["filename"]!!
 
-            val generationDate = Date()
+            val generationDate = LocalDate.now()
 
             val queryStr = call.request.uri.substringAfter('?', "")
             val query = parseQuery(queryStr).toMutableMap()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ScrambleViewHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/ScrambleViewHandler.kt
@@ -30,7 +30,7 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
-import java.util.*
+import java.time.LocalDate
 import javax.imageio.ImageIO
 
 class ScrambleViewHandler(val environmentConfig: ServerEnvironmentConfig) : RouteHandler {
@@ -133,7 +133,7 @@ class ScrambleViewHandler(val environmentConfig: ServerEnvironmentConfig) : Rout
                 val scrambleRequests = GSON.fromJson(query["sheets"], Array<ScrambleRequest>::class.java).toList()
                 val password = query["password"]
 
-                val generationDate = Date()
+                val generationDate = LocalDate.now()
 
                 when (extension) {
                     "pdf" -> {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/OrderedScrambles.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/OrderedScrambles.kt
@@ -7,12 +7,11 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Comp
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.atLocalStartOfDay
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest.Companion.putFileEntry
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFHelper.Companion.parseWCIFDateWithTimezone
+import java.time.LocalDate
 import java.time.Period
 
-import java.util.Date
-
 object OrderedScrambles {
-    fun generateOrderedScrambles(scrambleRequests: List<ScrambleRequest>, globalTitle: String?, generationDate: Date, versionTag: String, zipOut: ZipOutputStream, parameters: ZipParameters, wcifHelper: WCIFHelper) {
+    fun generateOrderedScrambles(scrambleRequests: List<ScrambleRequest>, globalTitle: String?, generationDate: LocalDate, versionTag: String, zipOut: ZipOutputStream, parameters: ZipParameters, wcifHelper: WCIFHelper) {
         if (wcifHelper.venues.isEmpty()) {
             return
         }


### PR DESCRIPTION
As it turns out, uppercase `Y` is *week year* (very strange ISO calendar thing for finance world) whereas lowercase `y` is the Gregorian Calendar year that we're all used to.

Similarly, lowercase `m` is actually the *minute* whereas uppercase `M` should be used for *month*