### PR TITLE
Turn ScrambleCacher work into Daemon threads

### DIFF
--- a/scrambles/src/main/java/net/gnehzr/tnoodle/scrambles/ScrambleCacher.java
+++ b/scrambles/src/main/java/net/gnehzr/tnoodle/scrambles/ScrambleCacher.java
@@ -87,6 +87,7 @@ public class ScrambleCacher {
                 }
             }
         });
+        t.setDaemon(true);
         running = true;
         t.start();
     }


### PR DESCRIPTION
One day I was debugging PDFs by using a simple custom main method:
1. Create dummy `ScrambleRequest`
2. Compile PDF, write to temporary debug file
3. Shut down

...except that the JVM was not shutting down because the ScrambleCacher threads were still running in the background. This is no big deal for the Delegates' JAR, because they would manually kill the server anyways, but it is annoying when using `scrambles` (prospective `lib-tnoodle`) as a standalone module.

If we want people to be able to use `ScrambleCacher` without much hassle (see for example #373) then we _should_ mark it as Daemon so the JVM can shut down gracefully if no other thread accesses the `ScrambleCacher` any more.