### PR TITLE
Move pruning folder code to separate feature branch

### DIFF
--- a/cloudscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/cloudscrambles/GoogleServerEnvironmentConfig.kt
+++ b/cloudscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/cloudscrambles/GoogleServerEnvironmentConfig.kt
@@ -1,20 +1,12 @@
 package org.worldcubeassociation.tnoodle.server.cloudscrambles
 
-import com.google.cloud.storage.BlobId
-import com.google.cloud.storage.BlobInfo
-import com.google.cloud.storage.StorageOptions
 import org.worldcubeassociation.tnoodle.server.util.ServerEnvironmentConfig
 import org.worldcubeassociation.tnoodle.server.util.WebServerUtils.DEVEL_VERSION
 import org.worldcubeassociation.tnoodle.server.util.WebServerUtils.callerClass
 import java.io.File
 import java.io.File.separator
-import java.io.InputStream
-import java.io.OutputStream
-import java.nio.channels.Channels
 
 object GoogleServerEnvironmentConfig : ServerEnvironmentConfig {
-    val GCS_SERVICE by lazy { StorageOptions.getDefaultInstance().service }
-
     private val CONFIG_FILE = javaClass.getResourceAsStream("/version.tnoodle")
     private val CONFIG_DATA = CONFIG_FILE?.reader()?.readLines() ?: listOf()
 
@@ -33,37 +25,9 @@ object GoogleServerEnvironmentConfig : ServerEnvironmentConfig {
         get() = CONFIG_DATA.getOrNull(1)
             ?: DEVEL_VERSION
 
-    override fun pruningTableExists(tableName: String): Boolean {
-        val blobId = remotePruningBlob(tableName)
-        return GCS_SERVICE.get(blobId)?.exists() ?: false
-    }
-
-    override fun getPruningTableInput(tableName: String): InputStream {
-        val blobId = remotePruningBlob(tableName)
-        val blobReader = GCS_SERVICE.get(blobId).reader()
-
-        return Channels.newInputStream(blobReader)
-    }
-
-    override fun getPruningTableOutput(tableName: String): OutputStream {
-        val blobId = remotePruningBlob(tableName)
-        val blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build()
-
-        val blobWriter = GCS_SERVICE.create(blobInfo).writer()
-
-        return Channels.newOutputStream(blobWriter)
-    }
-
-    private fun remotePruningBlob(tableName: String) = BlobId.of(getCloudBucketName(), tableName)
-
-    private fun getCloudHostname() = System.getProperty("com.google.appengine.application.id")
-    fun getCloudBucketName() = "${getCloudHostname()}.appspot.com"
-
     fun overrideFontConfig() {
         if (File(FONT_CONFIG).exists()) {
             System.setProperty(FONT_CONFIG_PROPERTY, FONT_CONFIG)
         }
     }
-
-    override fun createLocalPruningCache() = overrideFontConfig() // FIXME do we want this here implicitly?
 }

--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/TNoodleServer.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/TNoodleServer.kt
@@ -14,8 +14,6 @@ import org.worldcubeassociation.tnoodle.server.util.ServerEnvironmentConfig
 
 class TNoodleServer(val environmentConfig: ServerEnvironmentConfig) : ApplicationHandler {
     override fun spinUp(app: io.ktor.application.Application) {
-        environmentConfig.createLocalPruningCache()
-
         val versionHandler = VersionHandler(environmentConfig.projectTitle)
 
         app.routing {

--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/ServerEnvironmentConfig.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/util/ServerEnvironmentConfig.kt
@@ -1,19 +1,9 @@
 package org.worldcubeassociation.tnoodle.server.util
 
-import java.io.InputStream
-import java.io.OutputStream
-
 interface ServerEnvironmentConfig {
     val projectName: String
     val version: String
 
     val projectTitle
         get() = "$projectName-$version"
-
-    fun pruningTableExists(tableName: String): Boolean
-
-    fun getPruningTableInput(tableName: String): InputStream
-    fun getPruningTableOutput(tableName: String): OutputStream
-
-    fun createLocalPruningCache()
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/server/LocalServerEnvironmentConfig.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/server/LocalServerEnvironmentConfig.kt
@@ -16,45 +16,4 @@ object LocalServerEnvironmentConfig : ServerEnvironmentConfig {
     override val version
         get() = LocalServerEnvironmentConfig::class.java.getPackage()?.implementationVersion
             ?: DEVEL_VERSION
-
-    private fun getPruningTableCache(assertExists: Boolean = true): File {
-        val baseDir = File(programDirectory, PRUNING_FOLDER)
-
-        // Each version of tnoodle extracts its pruning tables
-        // to its own subdirectory of PRUNING_FOLDER
-        val file = baseDir.takeIf { version == DEVEL_VERSION }
-            ?: File(baseDir, version)
-
-        if (assertExists && !file.isDirectory) {
-            throw FileNotFoundException("${file.absolutePath} does not exist, or is not a directory")
-        }
-
-        return file
-    }
-
-    override fun pruningTableExists(tableName: String) = localPruningFile(tableName).exists()
-
-    override fun getPruningTableInput(tableName: String) = localPruningFile(tableName).inputStream()
-
-    override fun getPruningTableOutput(tableName: String) =
-        localPruningFile(tableName).takeIf { it.parentFile.isDirectory || it.parentFile.mkdirs() }?.outputStream()
-            ?: error("Unable to create pruning file for table '$tableName'")
-
-    private fun localPruningFile(tableName: String) = File(getPruningTableCache(false), "$tableName.prun")
-
-    override fun createLocalPruningCache() {
-        val jarFile = jarFile
-
-        if (jarFile != null) {
-            val pruningTableDirectory = getPruningTableCache(false)
-
-            if (pruningTableDirectory.isDirectory) {
-                // If the pruning table folder already exists, we don't bother re-extracting the
-                // files.
-                return
-            }
-
-            assert(pruningTableDirectory.mkdirs())
-        }
-    }
 }


### PR DESCRIPTION
Right now, we create an empty folder that is unused, because pruning is only (subject to being) added in #461 

Until the .15 releases, this folder used to be necessary for resources. But now, we can access these directly from within the JAR so we should not create an empty folder.

Merging as soon as Travis says Yes because this is only moving "dead code" to another branch that will then be reviewed again more thoroughly.