### PR TITLE
Require travis sudo to circumvent Maven caching problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: openjdk8
+sudo: required
 
 script:
   - ./gradlew publishToMavenLocal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk: openjdk8
-sudo: required
+sudo: true
 
 script:
   - ./gradlew publishToMavenLocal


### PR DESCRIPTION
We've been running into a lot of `403` problems with Travis CI builds, despite everything working on local.

https://travis-ci.org/thewca/tnoodle/builds/634197076
https://travis-ci.org/thewca/tnoodle/builds/634192912

As a fix, https://github.com/travis-ci/travis-ci/issues/6593 suggests enabling sudo mode.