### PR TITLE
Refactor FMC moves table and fit text methods

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
@@ -1,9 +1,6 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.pdf
 
-import com.itextpdf.text.Document
-import com.itextpdf.text.Element
-import com.itextpdf.text.Image
-import com.itextpdf.text.Rectangle
+import com.itextpdf.text.*
 import com.itextpdf.text.pdf.PdfWriter
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.Translate
@@ -12,7 +9,7 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.populateRect
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 
-class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?): FmcSheet(request, globalTitle) {
+class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?) : FmcSheet(request, globalTitle) {
     override fun PdfWriter.writeContents(document: Document) {
         for (i in scrambleRequest.scrambles.indices) {
             addFmcScrambleCutoutSheet(document, scrambleRequest, title, i)
@@ -51,9 +48,11 @@ class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?): Fm
 
         val paddedTitleItems = textList.zip(alignList)
 
+        val font = Font(BASE_FONT, FONT_SIZE)
+
         for (i in 0 until SCRAMBLES_PER_SHEET) {
             val rect = Rectangle(LEFT.toFloat(), (top - i * availableScrambleHeight).toFloat(), (right - dim.width - SPACE_SCRAMBLE_IMAGE).toFloat(), (top - (i + 1) * availableScrambleHeight).toFloat())
-            directContent.populateRect(rect, paddedTitleItems, BASE_FONT, FONT_SIZE)
+            directContent.populateRect(rect, paddedTitleItems, font)
 
             directContent.addImage(Image.getInstance(tp), dim.width.toDouble(), 0.0, 0.0, dim.height.toDouble(), (right - dim.width).toDouble(), top.toDouble() - (i + 1) * availableScrambleHeight + (availableScrambleHeight - dim.getHeight()) / 2)
 
@@ -72,7 +71,7 @@ class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?): Fm
         val SPACE_SCRAMBLE_IMAGE = 5 // scramble image won't touch the scramble
         val SCRAMBLE_IMAGE_PADDING = 8 // scramble image won't touch the dashed lines
 
-        val FONT_SIZE = 20
+        val FONT_SIZE = 20f
 
         val SCRAMBLES_PER_SHEET = 8
     }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
@@ -260,16 +260,15 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         val tableWidth = competitorInfoLeft - left - 2 * margin
         val tableHeight = rulesRect.bottom - scrambleBorderTop - 2 * margin
         val tableLines = movesType.size * (direction.size + 1) // +1 for the title
-        val cellWidth = 25
+        val firstColumnWidth = tableWidth / 2
+        val cellWidth = (tableWidth - firstColumnWidth) / WCA_MOVES.size
         val cellHeight = tableHeight / tableLines
-        val columns = 7
-        val firstColumnWidth = tableWidth - (columns - 1) * cellWidth
-
+        val columns = WCA_MOVES.size + 1 // +1 for the first column
         val movesFontSize = 10
         val movesFont = Font(bf, movesFontSize.toFloat())
 
         val table = PdfPTable(columns).apply {
-            setTotalWidth(floatArrayOf(firstColumnWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat()))
+            setTotalWidth(floatArrayOf(firstColumnWidth.toFloat(), *FloatArray(WCA_MOVES.size) { it -> cellWidth.toFloat() }))
             isLockedWidth = true
         }
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
@@ -143,13 +143,19 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
             cb.addImage(Image.getInstance(tp), dim.width.toFloat(), 0f, 0f, dim.height.toFloat(), (competitorInfoLeft + (availableScrambleWidth - dim.width) / 2).toFloat(), (scrambleBorderTop + (availableScrambleHeight - dim.height) / 2).toFloat())
         }
 
-        val fontSize = 15
+        val fontSize = 15f
+        val font = Font(bf, fontSize)
         val margin = 5
         val showScrambleCount = withScramble && (scrambleRequest.scrambles.size > 1 || scrambleRequest.totalAttempt > 1)
+        val titleFontSize = 25f
+        val titleFont = Font(bf, titleFontSize)
 
+        val titleRect = Rectangle(left.toFloat(), top.toFloat(), competitorInfoLeft.toFloat(), top.toFloat() - titleFontSize)
         val competitorInfoRect = Rectangle((competitorInfoLeft + margin).toFloat(), top.toFloat(), (right - margin).toFloat(), competitorInfoBottom.toFloat())
         val gradeRect = Rectangle((competitorInfoLeft + margin).toFloat(), competitorInfoBottom.toFloat(), (right - margin).toFloat(), gradeBottom.toFloat())
         val scrambleImageRect = Rectangle((competitorInfoLeft + margin).toFloat(), gradeBottom.toFloat(), (right - margin).toFloat(), scrambleBorderTop.toFloat())
+
+        cb.fitAndShowText(Translate.translate("fmc.event", locale), titleRect, titleFont, Element.ALIGN_CENTER)
 
         val personalDetailsItems = mutableListOf<Pair<String, Int>>()
 
@@ -206,7 +212,7 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
             personalDetailsItems.add("" to Element.ALIGN_LEFT)
         }
 
-        cb.populateRect(competitorInfoRect, personalDetailsItems, bf, fontSize)
+        cb.populateRect(competitorInfoRect, personalDetailsItems, font)
 
         // graded
         val gradingTextGradedBy = Translate.translate("fmc.graded", locale) + LONG_FILL
@@ -220,7 +226,8 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
             gradingText to Element.ALIGN_CENTER
         )
 
-        cb.populateRect(gradeRect, gradingItemsWithAlignment, bf, 11) // FIXME const
+        val gradedFont = Font(bf, 11f)
+        cb.populateRect(gradeRect, gradingItemsWithAlignment, gradedFont)
 
         if (!withScramble) {
             val separateSheetAdvice = Translate.translate("fmc.scrambleOnSeparateSheet", locale)
@@ -230,7 +237,7 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
                 separateSheetAdvice to Element.ALIGN_CENTER
             )
 
-            cb.populateRect(scrambleImageRect, separateSheetAdviceItems, bf, 11) // FIXME const
+            cb.populateRect(scrambleImageRect, separateSheetAdviceItems, gradedFont) // FIXME const
         }
 
         val fmcMargin = 10
@@ -331,15 +338,9 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         // Position the table
         table.writeSelectedRows(0, -1, left.toFloat() + fmcMargin.toFloat() + (cellWidth - maxLastColumnWidth) / 2 - (firstColumnWidth - maxFirstColumnWidth) / 2, (scrambleBorderTop + tableHeight + fmcMargin).toFloat(), cb)
 
-        // Rules
-        val leadingMultiplier = 1f
-        val ruleFontSize = 25
-
-        val rect = Rectangle(left.toFloat(), (top - MAGIC_NUMBER + ruleFontSize).toFloat(), competitorInfoLeft.toFloat(), (top - MAGIC_NUMBER).toFloat())
-        cb.fitAndShowText(Translate.translate("fmc.event", locale), bf, rect, ruleFontSize.toFloat(), Element.ALIGN_CENTER, leadingMultiplier)
-
         val substitutions = mapOf("maxMoves" to WCA_MAX_MOVES_FMC.toString())
 
+        // Rules
         val rulesList = listOf(
             Translate.translate("fmc.rule1", locale),
             Translate.translate("fmc.rule2", locale),
@@ -354,7 +355,8 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         val rulesRectangle = Rectangle((left + fmcMargin).toFloat(), (scrambleBorderTop + tableHeight + fmcMargin).toFloat(), (competitorInfoLeft - fmcMargin).toFloat(), (rulesTop + fmcMargin).toFloat())
         val rules = rulesList.joinToString("\n") { "• $it" }
 
-        cb.fitAndShowText(rules, bf, rulesRectangle, 15f, Element.ALIGN_JUSTIFIED, 1.5f) // TODO const
+        val rulesFont = Font(bf, 15f)
+        cb.fitAndShowText(rules, rulesRectangle, rulesFont, Element.ALIGN_JUSTIFIED, 1.5f)
 
         doc.newPage()
     }
@@ -363,8 +365,6 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         const val FMC_LINE_THICKNESS = 0.5f
 
         const val UNDERLINE_THICKNESS = 0.2f
-
-        const val MAGIC_NUMBER = 30 // kill me now
 
         const val FORM_TEMPLATE_WCA_ID = "WCA ID: __ __ __ __  __ __ __ __  __ __"
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/ScrambleZip.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/ScrambleZip.kt
@@ -95,9 +95,8 @@ data class ScrambleZip(val scrambleRequests: List<ScrambleRequest>, val wcifBind
             }
 
             if (fmcRequests.isNotEmpty()) {
-                file("3x3x3 Fewest Moves Solution Sheet.pdf", genericSolutionSheetPdf.render())
-
                 folder("Fewest Moves - Additional Files") {
+                    file("3x3x3 Fewest Moves Solution Sheet.pdf", genericSolutionSheetPdf.render())
                     for ((uniq, req) in fmcRequests) {
                         val cutoutZipName = "$uniq - Scramble Cutout Sheet.pdf"
                         val cutoutSheet = FmcScrambleCutoutSheet(req, globalTitle)


### PR DESCRIPTION
The main idea here is to render the moves table in a similar way we do to the other texts (positioning on rects). This will make it easier to maintain.