### PR TITLE
Clean up PDF generation methods

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
@@ -246,7 +246,7 @@ data class ScrambleRequest(
                 computerDisplayZipOut.putFileEntry(computerDisplayZipName, pdfPrintingByteStream.render(passcode), computerDisplayZipParameters)
 
                 val txtZipName = "Interchange/txt/$safeTitle.txt"
-                val txtScrambles = stripNewlines(scrambleRequest.allScrambles).joinToString("\r\n")
+                val txtScrambles = scrambleRequest.allScrambles.stripNewlines().joinToString("\r\n")
 
                 zipOut.putFileEntry(txtZipName, txtScrambles.toByteArray(), parameters)
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/ScrambleRequest.kt
@@ -30,6 +30,7 @@ data class ScrambleRequest(
     val title: String,
     val fmc: Boolean,
     val colorScheme: HashMap<String, SVGColor>?,
+
     // totalAttempt and attempt are useful for when we have multiple attempts split in the schedule.
     // Usually, tnoodle prints scrambles for a ScrambleRequest iterating over ScrambleRequest.scrambles.
     // So, if ScrambleRequest.scrambles.length == 3, tnoodle prints Scramble 1 of 3, Scramble 2 of 3 and Scramble 3 of 3.

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
@@ -48,19 +48,20 @@ class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?): Fm
             g2.dispose()
         }
 
-        var title = "$globalTitle - ${scrambleRequest.title}"
+        val scrambleSuffix = " - Scramble ${index + 1} of ${scrambleRequest.scrambles.size}"
+            .takeIf { scrambleRequest.scrambles.size > 1 } ?: ""
 
-        if (scrambleRequest.scrambles.size > 1) {
-            title += " - Scramble ${index + 1} of ${scrambleRequest.scrambles.size}"
-        }
+        val title = "$globalTitle - ${scrambleRequest.title}$scrambleSuffix"
 
         // empty strings for space above and below
         val textList = listOf("", title, scramble, "")
         val alignList = List(textList.size) { Element.ALIGN_LEFT }
 
+        val paddedTitleItems = textList.zip(alignList)
+
         for (i in 0 until SCRAMBLES_PER_SHEET) {
             val rect = Rectangle(LEFT.toFloat(), (top - i * availableScrambleHeight).toFloat(), (right - dim.width - SPACE_SCRAMBLE_IMAGE).toFloat(), (top - (i + 1) * availableScrambleHeight).toFloat())
-            directContent.populateRect(rect, textList, alignList, BASE_FONT, FONT_SIZE)
+            directContent.populateRect(rect, paddedTitleItems, BASE_FONT, FONT_SIZE)
 
             directContent.addImage(Image.getInstance(tp), dim.width.toDouble(), 0.0, 0.0, dim.height.toDouble(), (right - dim.width).toDouble(), top.toDouble() - (i + 1) * availableScrambleHeight + (availableScrambleHeight - dim.getHeight()) / 2)
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
@@ -1,7 +1,5 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.pdf
 
-import com.itextpdf.awt.DefaultFontMapper
-import com.itextpdf.awt.PdfGraphics2D
 import com.itextpdf.text.Element
 import com.itextpdf.text.Image
 import com.itextpdf.text.Rectangle
@@ -9,7 +7,7 @@ import com.itextpdf.text.pdf.PdfWriter
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.Translate
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.drawDashedLine
-import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.drawSvg
+import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.renderSvgToPDF
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.populateRect
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 
@@ -37,16 +35,9 @@ class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?): Fm
         val availablePaddedScrambleHeight = availableScrambleHeight - 2 * SCRAMBLE_IMAGE_PADDING
 
         val dim = scrambleRequest.scrambler.getPreferredSize(availableScrambleWidth, availablePaddedScrambleHeight)
+        val svg = scrambleRequest.scrambler.drawScramble(scramble, scrambleRequest.colorScheme)
 
-        val tp = directContent.createTemplate(dim.width.toFloat(), dim.height.toFloat())
-        val g2 = PdfGraphics2D(tp, dim.width.toFloat(), dim.height.toFloat(), DefaultFontMapper())
-
-        try {
-            val svg = scrambleRequest.scrambler.drawScramble(scramble, scrambleRequest.colorScheme)
-            g2.drawSvg(svg, dim)
-        } finally {
-            g2.dispose()
-        }
+        val tp = directContent.renderSvgToPDF(svg, dim)
 
         val scrambleSuffix = " - Scramble ${index + 1} of ${scrambleRequest.scrambles.size}"
             .takeIf { scrambleRequest.scrambles.size > 1 } ?: ""

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
@@ -15,8 +15,11 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil
 import java.util.*
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
 
-open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, locale: Locale): FmcSheet(request, globalTitle, locale) {
+open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, locale: Locale) : FmcSheet(request, globalTitle, locale) {
     override fun PdfWriter.writeContents() {
         for (i in scrambleRequest.scrambles.indices) {
             addFmcSolutionSheet(document, scrambleRequest, title, i, locale)
@@ -25,13 +28,9 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
     }
 
     protected fun PdfWriter.addFmcSolutionSheet(doc: Document, scrambleRequest: ScrambleRequest, globalTitle: String?, index: Int, locale: Locale) {
-        var index = index
         val withScramble = index != -1
         val pageSize = doc.pageSize
-        var scramble: String? = null
-        if (withScramble) {
-            scramble = scrambleRequest.scrambles[index]
-        }
+
         val cb = directContent
         val bf = FontUtil.getFontForLocale(locale)
 
@@ -92,40 +91,44 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         val availableSolutionHeight = scrambleBorderTop - bottom
         val lineWidth = 25
         val linesX = 10
-        val linesY = Math.ceil(1.0 * WCA_MAX_MOVES_FMC / linesX).toInt()
+        val linesY = ceil(1.0 * WCA_MAX_MOVES_FMC / linesX).toInt()
 
         cb.setLineWidth(FMC_LINE_THICKNESS)
         cb.stroke()
 
         val excessX = availableSolutionWidth - linesX * lineWidth
-        var moveCount = 0
-        solutionLines@ for (y in 0 until linesY) {
+
+        for (y in 0 until linesY) {
             for (x in 0 until linesX) {
+                val moveCount = y * linesY + x
+
                 if (moveCount >= WCA_MAX_MOVES_FMC) {
-                    break@solutionLines
+                    break
                 }
+
                 val xPos = left + x * lineWidth + (x + 1) * excessX / (linesX + 1)
                 val yPos = (if (withScramble) solutionBorderTop else scrambleBorderTop) - (y + 1) * availableSolutionHeight / (linesY + 1)
+
                 cb.moveTo(xPos.toFloat(), yPos.toFloat())
                 cb.lineTo((xPos + lineWidth).toFloat(), yPos.toFloat())
-                moveCount++
             }
         }
 
-        val UNDERLINE_THICKNESS = 0.2f
         cb.setLineWidth(UNDERLINE_THICKNESS)
         cb.stroke()
 
         if (withScramble) {
+            val scramble = scrambleRequest.scrambles[index]
+
             cb.beginText()
-            val availableScrambleSpace = right - left - 2 * padding
-            var scrambleFontSize = 20
             val scrambleStr = Translate.translate("fmc.scramble", locale) + ": " + scramble
-            var scrambleWidth: Float
-            do {
-                scrambleFontSize--
-                scrambleWidth = bf.getWidthPoint(scrambleStr, scrambleFontSize.toFloat())
-            } while (scrambleWidth > availableScrambleSpace)
+
+            val availableScrambleSpace = right - left - 2 * padding
+
+            val scrambleFontSizes = 0 until 20
+            val scrambleFontSize = scrambleFontSizes.reversed().find {
+                bf.getWidthPoint(scrambleStr, it.toFloat()) <= availableScrambleSpace
+            } ?: 20
 
             cb.setFontAndSize(bf, scrambleFontSize.toFloat())
             val scrambleY = 3 + solutionBorderTop + (scrambleBorderTop - solutionBorderTop - scrambleFontSize) / 2
@@ -134,6 +137,7 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
 
             val availableScrambleWidth = right - competitorInfoLeft
             val availableScrambleHeight = gradeBottom - scrambleBorderTop
+
             val dim = scrambleRequest.scrambler.getPreferredSize(availableScrambleWidth - 2, availableScrambleHeight - 2)
             val tp = cb.createTemplate(dim.width.toFloat(), dim.height.toFloat())
             val g2 = PdfGraphics2D(tp, dim.width.toFloat(), dim.height.toFloat(), DefaultFontMapper())
@@ -148,7 +152,7 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
             cb.addImage(Image.getInstance(tp), dim.width.toFloat(), 0f, 0f, dim.height.toFloat(), (competitorInfoLeft + (availableScrambleWidth - dim.width) / 2).toFloat(), (scrambleBorderTop + (availableScrambleHeight - dim.height) / 2).toFloat())
         }
 
-        var fontSize = 15
+        val fontSize = 15
         val margin = 5
         val showScrambleCount = withScramble && (scrambleRequest.scrambles.size > 1 || scrambleRequest.totalAttempt > 1)
 
@@ -156,90 +160,86 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         val gradeRect = Rectangle((competitorInfoLeft + margin).toFloat(), competitorInfoBottom.toFloat(), (right - margin).toFloat(), gradeBottom.toFloat())
         val scrambleImageRect = Rectangle((competitorInfoLeft + margin).toFloat(), gradeBottom.toFloat(), (right - margin).toFloat(), scrambleBorderTop.toFloat())
 
-        val shortFill = ": ____"
-        val longFill = ": __________________"
-
-        // competitor and competition info
-        var list = ArrayList<String>()
-        var alignList = ArrayList<Int>()
+        val personalDetailsItems = mutableListOf<Pair<String, Int>>()
 
         if (withScramble) {
-            list.add(globalTitle!!)
-            alignList.add(Element.ALIGN_CENTER)
-            list.add(scrambleRequest.title)
-            alignList.add(Element.ALIGN_CENTER)
+            personalDetailsItems.add(globalTitle!! to Element.ALIGN_CENTER)
+            personalDetailsItems.add(scrambleRequest.title to Element.ALIGN_CENTER)
 
             if (showScrambleCount) {
-                if (scrambleRequest.totalAttempt > 1) { // this is for ordered scrambles
-                    index = Math.max(scrambleRequest.attempt - 1, index)
-                }
+                // this is for ordered scrambles
+                val attemptIndex = scrambleRequest.takeIf { it.totalAttempt > 1 }?.attempt ?: index
+                val orderedIndex = max(attemptIndex, index)
 
                 val absoluteTotal = scrambleRequest.totalAttempt.takeIf { it > 1 } ?: scrambleRequest.scrambles.size
 
                 val substitutions = mapOf(
-                    "scrambleIndex" to (index + 1).toString(),
+                    "scrambleIndex" to (orderedIndex + 1).toString(),
                     "scrambleCount" to absoluteTotal.toString()
                 )
 
-                list.add(Translate.translate("fmc.scrambleXofY", locale, substitutions))
-                alignList.add(Element.ALIGN_CENTER)
+                val translatedInfo = Translate.translate("fmc.scrambleXofY", locale, substitutions)
+                personalDetailsItems.add(translatedInfo to Element.ALIGN_CENTER)
             }
         } else {
-            list.add(Translate.translate("fmc.competition", locale) + longFill)
-            alignList.add(Element.ALIGN_LEFT)
-            list.add(Translate.translate("fmc.round", locale) + shortFill)
-            alignList.add(Element.ALIGN_LEFT)
-            list.add(Translate.translate("fmc.attempt", locale) + shortFill)
-            alignList.add(Element.ALIGN_LEFT)
-        }
-        if (withScramble) { // more space for filling name
-            list.add("")
-            alignList.add(Element.ALIGN_LEFT)
-        }
-        list.add(Translate.translate("fmc.competitor", locale) + longFill)
-        alignList.add(Element.ALIGN_LEFT)
-        if (withScramble) {
-            list.add("")
-            alignList.add(Element.ALIGN_LEFT)
-        }
-        list.add("WCA ID: __ __ __ __  __ __ __ __  __ __")
-        alignList.add(Element.ALIGN_LEFT)
-        if (withScramble) { // add space below
-            list.add("")
-            alignList.add(Element.ALIGN_LEFT)
-        }
-        list.add(Translate.translate("fmc.registrantId", locale) + shortFill)
-        alignList.add(Element.ALIGN_LEFT)
-        if (withScramble) {
-            list.add("")
-            alignList.add(Element.ALIGN_LEFT)
+            val competitionDesc = Translate.translate("fmc.competition", locale) + LONG_FILL
+            val roundDesc = Translate.translate("fmc.round", locale) + SHORT_FILL
+            val attemptDesc = Translate.translate("fmc.attempt", locale) + SHORT_FILL
+
+            personalDetailsItems.add(competitionDesc to Element.ALIGN_LEFT)
+            personalDetailsItems.add(roundDesc to Element.ALIGN_LEFT)
+            personalDetailsItems.add(attemptDesc to Element.ALIGN_LEFT)
         }
 
-        cb.populateRect(competitorInfoRect, list, alignList, bf, fontSize)
+        if (withScramble) { // more space for filling name
+            personalDetailsItems.add("" to Element.ALIGN_LEFT)
+        }
+
+        val competitorDesc = Translate.translate("fmc.competitor", locale) + LONG_FILL
+        personalDetailsItems.add(competitorDesc to Element.ALIGN_LEFT)
+
+        if (withScramble) {
+            personalDetailsItems.add("" to Element.ALIGN_LEFT)
+        }
+
+        personalDetailsItems.add(FORM_TEMPLATE_WCA_ID to Element.ALIGN_LEFT)
+
+        if (withScramble) { // add space below
+            personalDetailsItems.add("" to Element.ALIGN_LEFT)
+        }
+
+        val registrantIdDesc = Translate.translate("fmc.registrantId", locale) + SHORT_FILL
+        personalDetailsItems.add(registrantIdDesc to Element.ALIGN_LEFT)
+
+        if (withScramble) {
+            personalDetailsItems.add("" to Element.ALIGN_LEFT)
+        }
+
+        cb.populateRect(competitorInfoRect, personalDetailsItems, bf, fontSize)
 
         // graded
-        list = ArrayList()
-        alignList = ArrayList()
-        list.add(Translate.translate("fmc.warning", locale))
-        alignList.add(Element.ALIGN_CENTER)
-        list.add(Translate.translate("fmc.graded", locale) + longFill + " " + Translate.translate("fmc.result", locale) + shortFill)
-        alignList.add(Element.ALIGN_CENTER)
-        fontSize = 11
-        cb.populateRect(gradeRect, list, alignList, bf, fontSize)
+        val gradingTextGradedBy = Translate.translate("fmc.graded", locale) + LONG_FILL
+        val gradingTextResult = Translate.translate("fmc.result", locale) + SHORT_FILL
+
+        val gradingText = "$gradingTextGradedBy $gradingTextResult"
+        val warningText = Translate.translate("fmc.warning", locale)
+
+        val gradingItemsWithAlignment = listOf(
+            warningText to Element.ALIGN_CENTER,
+            gradingText to Element.ALIGN_CENTER
+        )
+
+        cb.populateRect(gradeRect, gradingItemsWithAlignment, bf, 11) // FIXME const
 
         if (!withScramble) {
-            fontSize = 11
+            val separateSheetAdvice = Translate.translate("fmc.scrambleOnSeparateSheet", locale)
 
-            list = ArrayList()
-            alignList = ArrayList()
+            val separateSheetAdviceItems = listOf(
+                "" to Element.ALIGN_CENTER,
+                separateSheetAdvice to Element.ALIGN_CENTER
+            )
 
-            list.add("") // fake vertical centering
-            alignList.add(Element.ALIGN_CENTER)
-
-            list.add(Translate.translate("fmc.scrambleOnSeparateSheet", locale))
-            alignList.add(Element.ALIGN_CENTER)
-
-            cb.populateRect(scrambleImageRect, list, alignList, bf, fontSize)
+            cb.populateRect(scrambleImageRect, separateSheetAdviceItems, bf, 11) // FIXME const
         }
 
         val fmcMargin = 10
@@ -256,87 +256,83 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         val movesFontSize = 10
         val movesFont = Font(bf, movesFontSize.toFloat())
 
-        val table = PdfPTable(columns)
-        table.setTotalWidth(floatArrayOf(firstColumnWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat()))
-        table.isLockedWidth = true
-
-        val movesType = arrayOf(Translate.translate("fmc.faceMoves", locale), Translate.translate("fmc.rotations", locale))
-        val direction = arrayOf(Translate.translate("fmc.clockwise", locale), Translate.translate("fmc.counterClockwise", locale), Translate.translate("fmc.double", locale))
-
-        val directionModifiers = arrayOf("", "'", "2")
-        val moves = arrayOf("R", "U", "F", "L", "D", "B")
-        val rotations = arrayOf("x", "y", "z", "", "", "")
-        val movesCell = Array(movesType.size) { Array<Array<String?>>(direction.size) { arrayOfNulls(moves.size) } }
-
-        // Face moves.
-        for (i in directionModifiers.indices) {
-            for (j in moves.indices) {
-                movesCell[0][i][j] = moves[j] + directionModifiers[i]
-            }
+        val table = PdfPTable(columns).apply {
+            setTotalWidth(floatArrayOf(firstColumnWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat(), cellWidth.toFloat()))
+            isLockedWidth = true
         }
-        // Rotations.
-        for (i in directionModifiers.indices) {
-            for (j in rotations.indices) {
-                if (!rotations[j].isBlank()) {
-                    movesCell[1][i][j] = rotations[j].toLowerCase() + directionModifiers[i]
-                } else {
-                    movesCell[1][i][j] = "";
-                }
-            }
-        }
+
+        val movesType = listOf(
+            Translate.translate("fmc.faceMoves", locale),
+            Translate.translate("fmc.rotations", locale)
+        )
+
+        val direction = listOf(
+            Translate.translate("fmc.clockwise", locale),
+            Translate.translate("fmc.counterClockwise", locale),
+            Translate.translate("fmc.double", locale)
+        )
+
+        val pureMoves = DIRECTION_MODIFIERS.map { mod -> WCA_MOVES.map { mov -> "$mov$mod" } }
+        val rotationMoves = DIRECTION_MODIFIERS.map { mod -> WCA_MOVES.map { mov -> "[${mov.toLowerCase()}$mod]" } }
+
+        val movesCell = listOf(pureMoves, rotationMoves)
 
         val firstColumnRectangle = Rectangle(firstColumnWidth.toFloat(), cellHeight.toFloat())
-        var firstColumnFontSize = PdfUtil.fitText(Font(bf), movesType[0], firstColumnRectangle, 10f, false, 1f)
+        val firstColumnBaseFontSize = PdfUtil.fitText(Font(bf), movesType[0], firstColumnRectangle, 10f, false, 1f)
 
-        for (item in movesType) {
-            firstColumnFontSize = Math.min(firstColumnFontSize, PdfUtil.fitText(Font(bf, firstColumnFontSize, Font.BOLD), item, firstColumnRectangle, 10f, false, 1f))
-        }
-        for (item in direction) {
-            firstColumnFontSize = Math.min(firstColumnFontSize, PdfUtil.fitText(Font(bf, firstColumnFontSize), item, firstColumnRectangle, 10f, false, 1f))
-        }
+        val movesTypeMinFont = movesType.map { PdfUtil.fitText(Font(bf, firstColumnBaseFontSize, Font.BOLD), it, firstColumnRectangle, 10f, false, 1f) }
+            .min() ?: firstColumnBaseFontSize
+
+        val directionMinFont = direction.map { PdfUtil.fitText(Font(bf, firstColumnBaseFontSize), it, firstColumnRectangle, 10f, false, 1f) }
+            .min() ?: firstColumnBaseFontSize
+
+        val firstColumnFontSize = min(firstColumnBaseFontSize, min(movesTypeMinFont, directionMinFont))
 
         // Center the table
-        var maxFirstColumnWidth = 0f
-        var maxLastColumnWidth = 0f
+        val movesTypeMaxWidth = movesType.map { bf.getWidthPoint(it, firstColumnFontSize) }.max() ?: 0f
+        val directionMaxWidth = direction.map { bf.getWidthPoint(it, firstColumnFontSize) }.max() ?: 0f
+        val maxFirstColumnWidth = max(movesTypeMaxWidth, directionMaxWidth)
+
+        val lastColumnValues = movesCell.flatMap { c -> c.map { it.last() } }
+        val maxLastColumnWidth = lastColumnValues.map { bf.getWidthPoint(it, movesFontSize.toFloat()) }.max() ?: 0f
 
         for (i in movesType.indices) {
+            val explanationStringCell = PdfPCell(Phrase(movesType[i], Font(bf, firstColumnFontSize, Font.BOLD))).apply {
+                fixedHeight = cellHeight.toFloat()
+                verticalAlignment = Element.ALIGN_MIDDLE
+                horizontalAlignment = Element.ALIGN_RIGHT
+                border = Rectangle.NO_BORDER
+            }
 
-            maxFirstColumnWidth = Math.max(maxFirstColumnWidth, bf.getWidthPoint(movesType[i], firstColumnFontSize))
+            table.addCell(explanationStringCell)
 
-            var cell = PdfPCell(Phrase(movesType[i], Font(bf, firstColumnFontSize, Font.BOLD)))
-            cell.fixedHeight = cellHeight.toFloat()
-            cell.verticalAlignment = Element.ALIGN_MIDDLE
-            cell.horizontalAlignment = Element.ALIGN_RIGHT
-            cell.border = Rectangle.NO_BORDER
-            table.addCell(cell)
+            val emptyCell = PdfPCell(Phrase("")).apply {
+                fixedHeight = cellHeight.toFloat()
+                colspan = columns - 1
+                border = Rectangle.NO_BORDER
+            }
 
-            cell = PdfPCell(Phrase(""))
-            cell.fixedHeight = cellHeight.toFloat()
-            cell.colspan = columns - 1
-            cell.border = Rectangle.NO_BORDER
-            table.addCell(cell)
+            table.addCell(emptyCell)
 
-            for (j in directionModifiers.indices) {
+            for (j in DIRECTION_MODIFIERS.indices) {
+                val directionTitleCell = PdfPCell(Phrase(direction[j], Font(bf, firstColumnFontSize))).apply {
+                    fixedHeight = cellHeight.toFloat()
+                    verticalAlignment = Element.ALIGN_MIDDLE
+                    horizontalAlignment = Element.ALIGN_RIGHT
+                    border = Rectangle.NO_BORDER
+                }
 
-                maxFirstColumnWidth = Math.max(maxFirstColumnWidth, bf.getWidthPoint(direction[j], firstColumnFontSize))
+                table.addCell(directionTitleCell)
 
-                cell = PdfPCell(Phrase(direction[j], Font(bf, firstColumnFontSize)))
-                cell.fixedHeight = cellHeight.toFloat()
-                cell.verticalAlignment = Element.ALIGN_MIDDLE
-                cell.horizontalAlignment = Element.ALIGN_RIGHT
-                cell.border = Rectangle.NO_BORDER
-                table.addCell(cell)
-                for (k in moves.indices) {
-                    cell = PdfPCell(Phrase(movesCell[i][j][k], movesFont))
-                    cell.fixedHeight = cellHeight.toFloat()
-                    cell.verticalAlignment = Element.ALIGN_MIDDLE
-                    cell.horizontalAlignment = Element.ALIGN_CENTER
-                    cell.border = Rectangle.NO_BORDER
-                    table.addCell(cell)
-
-                    if (k == moves.size - 1) {
-                        maxLastColumnWidth = Math.max(maxLastColumnWidth, bf.getWidthPoint(movesCell[i][j][k], movesFontSize.toFloat()))
+                for (k in WCA_MOVES.indices) {
+                    val moveStringCell = PdfPCell(Phrase(movesCell[i][j][k], movesFont)).apply {
+                        fixedHeight = cellHeight.toFloat()
+                        verticalAlignment = Element.ALIGN_MIDDLE
+                        horizontalAlignment = Element.ALIGN_CENTER
+                        border = Rectangle.NO_BORDER
                     }
+
+                    table.addCell(moveStringCell)
                 }
             }
         }
@@ -345,38 +341,46 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         table.writeSelectedRows(0, -1, left.toFloat() + fmcMargin.toFloat() + (cellWidth - maxLastColumnWidth) / 2 - (firstColumnWidth - maxFirstColumnWidth) / 2, (scrambleBorderTop + tableHeight + fmcMargin).toFloat(), cb)
 
         // Rules
-        val MAGIC_NUMBER = 30 // kill me now
-        var leadingMultiplier = 1f
-        fontSize = 25
+        val leadingMultiplier = 1f
+        val ruleFontSize = 25
 
-        val rect = Rectangle(left.toFloat(), (top - MAGIC_NUMBER + fontSize).toFloat(), competitorInfoLeft.toFloat(), (top - MAGIC_NUMBER).toFloat())
-        cb.fitAndShowText(Translate.translate("fmc.event", locale), bf, rect, fontSize.toFloat(), Element.ALIGN_CENTER, leadingMultiplier)
+        val rect = Rectangle(left.toFloat(), (top - MAGIC_NUMBER + ruleFontSize).toFloat(), competitorInfoLeft.toFloat(), (top - MAGIC_NUMBER).toFloat())
+        cb.fitAndShowText(Translate.translate("fmc.event", locale), bf, rect, ruleFontSize.toFloat(), Element.ALIGN_CENTER, leadingMultiplier)
 
-        val rulesList = ArrayList<String>()
-        rulesList.add("• " + Translate.translate("fmc.rule1", locale))
-        rulesList.add("• " + Translate.translate("fmc.rule2", locale))
-        rulesList.add("• " + Translate.translate("fmc.rule3", locale))
+        val substitutions = mapOf("maxMoves" to WCA_MAX_MOVES_FMC.toString())
 
-        val maxMoves = WCA_MAX_MOVES_FMC
-
-        val substitutions = HashMap<String, String>()
-        substitutions["maxMoves"] = "" + maxMoves
-        rulesList.add("• " + Translate.translate("fmc.rule4", locale, substitutions))
-
-        rulesList.add("• " + Translate.translate("fmc.rule5", locale))
-        rulesList.add("• " + Translate.translate("fmc.rule6", locale))
+        val rulesList = listOf(
+            Translate.translate("fmc.rule1", locale),
+            Translate.translate("fmc.rule2", locale),
+            Translate.translate("fmc.rule3", locale),
+            Translate.translate("fmc.rule4", locale, substitutions),
+            Translate.translate("fmc.rule5", locale),
+            Translate.translate("fmc.rule6", locale)
+        )
 
         val rulesTop = competitorInfoBottom + if (withScramble) 65 else 153
 
-        leadingMultiplier = 1.5f
         val rulesRectangle = Rectangle((left + fmcMargin).toFloat(), (scrambleBorderTop + tableHeight + fmcMargin).toFloat(), (competitorInfoLeft - fmcMargin).toFloat(), (rulesTop + fmcMargin).toFloat())
-        val rules = rulesList.joinToString("\n")
-        cb.fitAndShowText(rules, bf, rulesRectangle, 15f, Element.ALIGN_JUSTIFIED, leadingMultiplier)
+        val rules = rulesList.joinToString("\n") { "• $it" }
+
+        cb.fitAndShowText(rules, bf, rulesRectangle, 15f, Element.ALIGN_JUSTIFIED, 1.5f) // TODO const
 
         doc.newPage()
     }
 
     companion object {
         const val FMC_LINE_THICKNESS = 0.5f
+
+        const val UNDERLINE_THICKNESS = 0.2f
+
+        const val MAGIC_NUMBER = 30 // kill me now
+
+        const val FORM_TEMPLATE_WCA_ID = "WCA ID: __ __ __ __  __ __ __ __  __ __"
+
+        const val SHORT_FILL = ": ____"
+        const val LONG_FILL = ": __________________"
+
+        val WCA_MOVES = arrayOf("F", "R", "U", "B", "L", "D")
+        val DIRECTION_MODIFIERS = arrayOf("", "'", "2")
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
@@ -1,7 +1,5 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.pdf
 
-import com.itextpdf.awt.DefaultFontMapper
-import com.itextpdf.awt.PdfGraphics2D
 import com.itextpdf.text.*
 import com.itextpdf.text.pdf.PdfContentByte
 import com.itextpdf.text.pdf.PdfPCell
@@ -9,7 +7,7 @@ import com.itextpdf.text.pdf.PdfPTable
 import com.itextpdf.text.pdf.PdfWriter
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.Translate
-import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.drawSvg
+import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.renderSvgToPDF
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.fitAndShowText
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.populateRect
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
@@ -139,15 +137,8 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
             val availableScrambleHeight = gradeBottom - scrambleBorderTop
 
             val dim = scrambleRequest.scrambler.getPreferredSize(availableScrambleWidth - 2, availableScrambleHeight - 2)
-            val tp = cb.createTemplate(dim.width.toFloat(), dim.height.toFloat())
-            val g2 = PdfGraphics2D(tp, dim.width.toFloat(), dim.height.toFloat(), DefaultFontMapper())
-
-            try {
-                val svg = scrambleRequest.scrambler.drawScramble(scramble, scrambleRequest.colorScheme)
-                g2.drawSvg(svg, dim)
-            } finally {
-                g2.dispose()
-            }
+            val svg = scrambleRequest.scrambler.drawScramble(scramble, scrambleRequest.colorScheme)
+            val tp = cb.renderSvgToPDF(svg, dim)
 
             cb.addImage(Image.getInstance(tp), dim.width.toFloat(), 0f, 0f, dim.height.toFloat(), (competitorInfoLeft + (availableScrambleWidth - dim.width) / 2).toFloat(), (scrambleBorderTop + (availableScrambleHeight - dim.height) / 2).toFloat())
         }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
@@ -13,6 +13,7 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil.spl
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.StringUtil
+import kotlin.math.log10
 import kotlin.math.min
 
 class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String?) : BaseScrambleSheet(scrambleRequest, globalTitle) {
@@ -76,7 +77,7 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
     }
 
     fun getIndexColumnWidth(scrambles: List<String>, scrambleNumberPrefix: String): Float {
-        val scramblesOrdinalLength = scrambles.size.toString().length
+        val scramblesOrdinalLength = log10(scrambles.size.toDouble()).toInt()
         // + 1 at the end represents the dot.
         val charsWide = scrambleNumberPrefix.length + scramblesOrdinalLength + 1
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
@@ -1,7 +1,5 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.pdf
 
-import com.itextpdf.awt.DefaultFontMapper
-import com.itextpdf.awt.PdfGraphics2D
 import com.itextpdf.text.*
 import com.itextpdf.text.pdf.PdfPCell
 import com.itextpdf.text.pdf.PdfPTable
@@ -10,7 +8,7 @@ import net.gnehzr.tnoodle.scrambles.Puzzle
 import net.gnehzr.tnoodle.svglite.Color
 import net.gnehzr.tnoodle.svglite.Dimension
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
-import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.drawSvg
+import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.renderSvgToPDF
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil.splitToLineChunks
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil
@@ -199,20 +197,8 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
             table.addCell(scrambleCell)
 
             if (scrambleImageSize.width > 0 && scrambleImageSize.height > 0) {
-                val tp = cb.createTemplate((scrambleImageSize.width + 2 * SCRAMBLE_IMAGE_PADDING).toFloat(), (scrambleImageSize.height + 2 * SCRAMBLE_IMAGE_PADDING).toFloat())
-                val g2 = PdfGraphics2D(tp, tp.width, tp.height, DefaultFontMapper())
-                g2.translate(SCRAMBLE_IMAGE_PADDING, SCRAMBLE_IMAGE_PADDING)
-
-                try {
-                    val svg = scrambler.drawScramble(scramble, colorScheme)
-                    g2.drawSvg(svg, scrambleImageSize)
-                } catch (e: Exception) {
-                    table.addCell("Error drawing scramble: " + e.message)
-                    // FIXME l.log(Level.WARNING, "Error drawing scramble, if you're having font issues, try installing ttf-dejavu.", e)
-                    continue
-                } finally {
-                    g2.dispose() // iTextPdf blows up if we do not dispose of this
-                }
+                val svg = scrambler.drawScramble(scramble, colorScheme)
+                val tp = cb.renderSvgToPDF(svg, scrambleImageSize, SCRAMBLE_IMAGE_PADDING)
 
                 val imgCell = PdfPCell(Image.getInstance(tp), true).apply {
                     backgroundColor = BaseColor.LIGHT_GRAY

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
@@ -17,6 +17,8 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.StringUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.TableAndHighlighting
 import java.util.HashMap
+import kotlin.math.log10
+import kotlin.math.min
 
 class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String?) : BaseScrambleSheet(scrambleRequest, globalTitle) {
     override fun PdfWriter.writeContents() {
@@ -25,24 +27,23 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
         val sideMargins = 100f + document.leftMargin() + document.rightMargin()
         val availableWidth = pageSize.width - sideMargins
         val vertMargins = document.topMargin() + document.bottomMargin()
-        var availableHeight = pageSize.height - vertMargins
 
-        if (scrambleRequest.extraScrambles.isNotEmpty()) {
-            availableHeight -= 20f // Yeee magic numbers. This should make space for the headerTable.
-        }
+        // Yeee magic numbers. This should make space for the headerTable.
+        val extraScrambleSpacing = 20.takeIf { scrambleRequest.extraScrambles.isNotEmpty() } ?: 0
 
-        val scramblesPerPage = Math.min(MAX_SCRAMBLES_PER_PAGE, scrambleRequest.allScrambles.size)
+        val availableHeight = pageSize.height - vertMargins - extraScrambleSpacing
+
+        val scramblesPerPage = min(MAX_SCRAMBLES_PER_PAGE, scrambleRequest.allScrambles.size)
         val maxScrambleImageHeight = (availableHeight / scramblesPerPage - 2 * SCRAMBLE_IMAGE_PADDING).toInt()
 
-        var maxScrambleImageWidth = (availableWidth / 2).toInt() // We don't let scramble images take up more than half the page
-
-        if (scrambleRequest.scrambler.shortName == "minx") {
+        // We don't let scramble images take up more than half the page
+        val maxScrambleImageWidth = (availableWidth / 2).toInt().takeUnless {
             // TODO - If we allow the megaminx image to be too wide, the
             //   Megaminx scrambles get really tiny. This tweak allocates
             //   a more optimal amount of space to the scrambles. This is possible
             //   because the scrambles are so uniformly sized.
-            maxScrambleImageWidth = 190
-        }
+            scrambleRequest.scrambler.shortName == "minx"
+        } ?: 190
 
         val scrambleImageSize = scrambleRequest.scrambler.getPreferredSize(maxScrambleImageWidth, maxScrambleImageHeight)
 
@@ -51,7 +52,7 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
         // if any scramble required it.
         var forceHighlighting = false
         for (dryRun in booleanArrayOf(true, false)) {
-            var scrambleNumberPrefix = ""
+            val scrambleNumberPrefix = ""
             val tableAndHighlighting = createTable(sideMargins, scrambleImageSize, scrambleRequest.scrambles, scrambleRequest.scrambler, scrambleRequest.colorScheme, scrambleNumberPrefix, forceHighlighting)
             if (dryRun) {
                 if (tableAndHighlighting.highlighting) {
@@ -63,20 +64,23 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
             }
 
             if (scrambleRequest.extraScrambles.isNotEmpty()) {
-                val headerTable = PdfPTable(1)
-                headerTable.setTotalWidth(floatArrayOf(availableWidth))
-                headerTable.isLockedWidth = true
+                val headerTable = PdfPTable(1).apply {
+                    setTotalWidth(floatArrayOf(availableWidth))
+                    isLockedWidth = true
+                }
 
-                val extraScramblesHeader = PdfPCell(Paragraph("Extra scrambles"))
-                extraScramblesHeader.verticalAlignment = PdfPCell.ALIGN_MIDDLE
-                extraScramblesHeader.paddingBottom = 3f
+                val extraScramblesHeader = PdfPCell(Paragraph("Extra scrambles")).apply {
+                    verticalAlignment = PdfPCell.ALIGN_MIDDLE
+                    paddingBottom = 3f
+                }
+
                 headerTable.addCell(extraScramblesHeader)
                 if (!dryRun) {
                     document.add(headerTable)
                 }
 
-                scrambleNumberPrefix = "E"
-                val extraTableAndHighlighting = createTable(sideMargins, scrambleImageSize, scrambleRequest.extraScrambles, scrambleRequest.scrambler, scrambleRequest.colorScheme, scrambleNumberPrefix, forceHighlighting)
+                val extraScrambleNumberPrefix = "E"
+                val extraTableAndHighlighting = createTable(sideMargins, scrambleImageSize, scrambleRequest.extraScrambles, scrambleRequest.scrambler, scrambleRequest.colorScheme, extraScrambleNumberPrefix, forceHighlighting)
                 if (dryRun) {
                     if (tableAndHighlighting.highlighting) {
                         forceHighlighting = true
@@ -92,76 +96,61 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
     fun PdfWriter.createTable(sideMargins: Float, scrambleImageSize: Dimension, scrambles: List<String>, scrambler: Puzzle, colorScheme: HashMap<String, Color>?, scrambleNumberPrefix: String, forceHighlighting: Boolean): TableAndHighlighting {
         val cb = directContent
 
-        val table = PdfPTable(3)
+        val leadingMultiplier = 1f
 
-        var leadingMultiplier = 1f
+        val charsWide = scrambleNumberPrefix.length + 1 + log10(scrambles.size.toDouble()).toInt()
+        // M has got to be as wide or wider than the widest digit in our font
+        val wideString = WIDEST_CHAR_STRING.repeat(charsWide) + "."
 
-        val charsWide = scrambleNumberPrefix.length + 1 + Math.log10(scrambles.size.toDouble()).toInt()
-        var wideString = ""
-        for (i in 0 until charsWide) {
-            // M has got to be as wide or wider than the widest digit in our font
-            wideString += "M"
-        }
-        wideString += "."
-        var col1Width = Chunk(wideString).widthPoint
-        // I don't know why we need this, perhaps there's some padding?
-        col1Width += 5f
+        // I don't know why we need the +5, perhaps there's some padding?
+        val col1Width = Chunk(wideString).widthPoint + 5f
 
         val availableWidth = pageSize.width - sideMargins
         val scrambleColumnWidth = availableWidth - col1Width - scrambleImageSize.width.toFloat() - (2 * SCRAMBLE_IMAGE_PADDING).toFloat()
         val availableScrambleHeight = scrambleImageSize.height - 2 * SCRAMBLE_IMAGE_PADDING
 
-        table.setTotalWidth(floatArrayOf(col1Width, scrambleColumnWidth, (scrambleImageSize.width + 2 * SCRAMBLE_IMAGE_PADDING).toFloat()))
-        table.isLockedWidth = true
-
-        var longestScramble = ""
-        var longestPaddedScramble = ""
-        for (scramble in scrambles) {
-            if (scramble.length > longestScramble.length) {
-                longestScramble = scramble
-            }
-
-            val paddedScramble = StringUtil.padTurnsUniformly(scramble, "M")
-            if (paddedScramble.length > longestPaddedScramble.length) {
-                longestPaddedScramble = paddedScramble
-            }
+        val table = PdfPTable(3).apply {
+            setTotalWidth(floatArrayOf(col1Width, scrambleColumnWidth, (scrambleImageSize.width + 2 * SCRAMBLE_IMAGE_PADDING).toFloat()))
+            isLockedWidth = true
         }
+
+        val longestScramble = scrambles.maxBy { it.length } ?: ""
+
+        val longestPaddedScrambleRaw = scrambles.map { StringUtil.padTurnsUniformly(it, WIDEST_CHAR_STRING) }
+            .maxBy { it.length } ?: ""
+
         // I don't know how to configure ColumnText.fitText's word wrapping characters,
         // so instead, I just replace each character I don't want to wrap with M, which
         // should be the widest character (we're using a monospaced font,
         // so that doesn't really matter), and won't get wrapped.
-        val widestCharacter = 'M'
-        longestPaddedScramble = longestPaddedScramble.replace("\\S".toRegex(), widestCharacter + "")
-        var tryToFitOnOneLine = true
-        if (longestPaddedScramble.indexOf("\n") >= 0) {
+        var longestPaddedScramble = longestPaddedScrambleRaw.replace("\\S".toRegex(), WIDEST_CHAR_STRING)
+
+        val tryToFitOnOneLine = "\n" !in longestPaddedScramble
+        if (tryToFitOnOneLine) {
             // If the scramble contains newlines, then we *only* allow wrapping at the
             // newlines.
-            longestPaddedScramble = longestPaddedScramble.replace(" ".toRegex(), "M")
-            tryToFitOnOneLine = false
+            longestPaddedScramble = longestPaddedScramble.replace(" ".toRegex(), WIDEST_CHAR_STRING)
         }
-        var oneLine = false
-        val scrambleFont: Font?
-
         val availableArea = Rectangle(scrambleColumnWidth - 2 * SCRAMBLE_PADDING_HORIZONTAL,
             (availableScrambleHeight - SCRAMBLE_PADDING_VERTICAL_TOP - SCRAMBLE_PADDING_VERTICAL_BOTTOM).toFloat())
-        var perfectFontSize = PdfUtil.fitText(Font(FontUtil.MONO_FONT), longestPaddedScramble, availableArea, FontUtil.MAX_SCRAMBLE_FONT_SIZE, true, leadingMultiplier)
-        if (tryToFitOnOneLine) {
-            val longestScrambleOneLine = longestScramble.replace(".".toRegex(), widestCharacter + "")
-            val perfectFontSizeForOneLine = PdfUtil.fitText(Font(FontUtil.MONO_FONT), longestScrambleOneLine, availableArea, FontUtil.MAX_SCRAMBLE_FONT_SIZE, false, leadingMultiplier)
-            oneLine = perfectFontSizeForOneLine >= FontUtil.MINIMUM_ONE_LINE_FONT_SIZE
-            if (oneLine) {
-                perfectFontSize = perfectFontSizeForOneLine
-            }
-        }
-        scrambleFont = Font(FontUtil.MONO_FONT, perfectFontSize, Font.NORMAL)
+
+        val longestScrambleOneLine = longestScramble.replace(".".toRegex(), WIDEST_CHAR_STRING)
+        val perfectFontSizeForOneLine = PdfUtil.fitText(Font(FontUtil.MONO_FONT), longestScrambleOneLine, availableArea, FontUtil.MAX_SCRAMBLE_FONT_SIZE, false, leadingMultiplier)
+
+        val oneLine = tryToFitOnOneLine && perfectFontSizeForOneLine >= FontUtil.MINIMUM_ONE_LINE_FONT_SIZE
+
+        val perfectFontSize = PdfUtil.fitText(Font(FontUtil.MONO_FONT), longestPaddedScramble, availableArea, FontUtil.MAX_SCRAMBLE_FONT_SIZE, true, leadingMultiplier)
+            .takeUnless { oneLine } ?: perfectFontSizeForOneLine
+
+        val scrambleFont = Font(FontUtil.MONO_FONT, perfectFontSize, Font.NORMAL)
 
         var highlight = forceHighlighting
-        for (i in scrambles.indices) {
-            val scramble = scrambles[i]
-            val paddedScramble = if (oneLine) scramble else StringUtil.padTurnsUniformly(scramble, PdfUtil.NON_BREAKING_SPACE + "")
+        for ((i, scramble) in scrambles.withIndex()) {
+            val paddedScramble = if (oneLine) scramble else StringUtil.padTurnsUniformly(scramble, PdfUtil.NON_BREAKING_SPACE.toString())
             val ch = Chunk(scrambleNumberPrefix + (i + 1) + ".")
-            val nthscramble = PdfPCell(Paragraph(ch))
-            nthscramble.verticalAlignment = PdfPCell.ALIGN_MIDDLE
+            val nthscramble = PdfPCell(Paragraph(ch)).apply {
+                verticalAlignment = PdfPCell.ALIGN_MIDDLE
+            }
             table.addCell(nthscramble)
 
             val scramblePhrase = Phrase()
@@ -179,20 +168,22 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
                 nthLine++
             }
 
-            val scrambleCell = PdfPCell(Paragraph(scramblePhrase))
-            // We carefully inserted newlines ourselves to make stuff fit, don't
-            // let itextpdf wrap lines for us.
-            scrambleCell.isNoWrap = true
-            scrambleCell.verticalAlignment = PdfPCell.ALIGN_MIDDLE
-            // This shifts everything up a little bit, because I don't like how
-            // ALIGN_MIDDLE works.
-            scrambleCell.paddingTop = (-SCRAMBLE_PADDING_VERTICAL_TOP).toFloat()
-            scrambleCell.paddingBottom = SCRAMBLE_PADDING_VERTICAL_BOTTOM.toFloat()
-            scrambleCell.paddingLeft = SCRAMBLE_PADDING_HORIZONTAL.toFloat()
-            scrambleCell.paddingRight = SCRAMBLE_PADDING_HORIZONTAL.toFloat()
-            // We space lines a little bit more here - it still fits in the cell height
-            leadingMultiplier = 1.1f
-            scrambleCell.setLeading(0f, leadingMultiplier)
+            val scrambleCell = PdfPCell(Paragraph(scramblePhrase)).apply {
+                // We carefully inserted newlines ourselves to make stuff fit, don't
+                // let itextpdf wrap lines for us.
+                isNoWrap = true
+                verticalAlignment = PdfPCell.ALIGN_MIDDLE
+                // This shifts everything up a little bit, because I don't like how
+                // ALIGN_MIDDLE works.
+                paddingTop = (-SCRAMBLE_PADDING_VERTICAL_TOP).toFloat()
+                paddingBottom = SCRAMBLE_PADDING_VERTICAL_BOTTOM.toFloat()
+                paddingLeft = SCRAMBLE_PADDING_HORIZONTAL.toFloat()
+                paddingRight = SCRAMBLE_PADDING_HORIZONTAL.toFloat()
+                // We space lines a little bit more here - it still fits in the cell height
+                val extraLeadingMultiplier = 1.1f
+                setLeading(0f, extraLeadingMultiplier)
+            }
+
             table.addCell(scrambleCell)
 
             if (scrambleImageSize.width > 0 && scrambleImageSize.height > 0) {
@@ -210,10 +201,12 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
                 } finally {
                     g2.dispose() // iTextPdf blows up if we do not dispose of this
                 }
-                val imgCell = PdfPCell(Image.getInstance(tp), true)
-                imgCell.backgroundColor = BaseColor.LIGHT_GRAY
-                imgCell.verticalAlignment = PdfPCell.ALIGN_MIDDLE
-                imgCell.horizontalAlignment = PdfPCell.ALIGN_MIDDLE
+                val imgCell = PdfPCell(Image.getInstance(tp), true).apply {
+                    backgroundColor = BaseColor.LIGHT_GRAY
+                    verticalAlignment = PdfPCell.ALIGN_MIDDLE
+                    horizontalAlignment = PdfPCell.ALIGN_MIDDLE
+                }
+
                 table.addCell(imgCell)
             } else {
                 table.addCell("")
@@ -230,6 +223,8 @@ class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String
         const val SCRAMBLE_PADDING_VERTICAL_TOP = 3
         const val SCRAMBLE_PADDING_VERTICAL_BOTTOM = 6
         const val SCRAMBLE_PADDING_HORIZONTAL = 1
+
+        const val WIDEST_CHAR_STRING = "M"
 
         private const val MIN_LINES_TO_ALTERNATE_HIGHLIGHTING = 4
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfDrawUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfDrawUtil.kt
@@ -83,20 +83,18 @@ object PdfDrawUtil {
         addText(Paragraph(text, Font(bf, fontSize)))
     }
 
-    fun PdfContentByte.populateRect(rect: Rectangle, list: List<String>, alignList: List<Int>, bf: BaseFont, fontSize: Int) {
-        assert(list.size == alignList.size) { "Make sure that list and alignList are of the same size" }
-
+    fun PdfContentByte.populateRect(rect: Rectangle, itemsWithAlignment: List<Pair<String, Int>>, bf: BaseFont, fontSize: Int) {
         val totalHeight = rect.height
         val width = rect.width
 
         val x = rect.left
         val y = rect.top
 
-        val height = totalHeight / list.size
+        val height = totalHeight / itemsWithAlignment.size
 
-        for (i in list.indices) {
+        for ((i, content) in itemsWithAlignment.withIndex()) {
             val temp = Rectangle(x, y + height * i - totalHeight - fontSize.toFloat(), x + width, y + height * i - totalHeight)
-            fitAndShowText(list[i], bf, temp, 15f, alignList[i], 1f)
+            fitAndShowText(content.first, bf, temp, 15f, content.second, 1f)
         }
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfUtil.kt
@@ -3,17 +3,16 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util
 import com.itextpdf.text.Chunk
 import com.itextpdf.text.Font
 import com.itextpdf.text.Rectangle
-import java.util.LinkedList
 
 object PdfUtil {
     const val NON_BREAKING_SPACE = '\u00A0'
     const val TEXT_PADDING_HORIZONTAL = 1
 
-    fun String.splitToLineChunks(font: Font, textColumnWidth: Float): LinkedList<Chunk> {
+    fun String.splitToLineChunks(font: Font, textColumnWidth: Float): List<Chunk> {
         val availableTextWidth = textColumnWidth - 2 * TEXT_PADDING_HORIZONTAL
 
-        val lineChunks = LinkedList<Chunk>()
-        val lineList = split("\n".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val lineChunks = mutableListOf<Chunk>()
+        val lineList = split("\n".toRegex()).dropLastWhile { it.isEmpty() }
 
         for (line in lineList) {
             var startIndex = 0
@@ -99,6 +98,8 @@ object PdfUtil {
         return lineChunks
     }
 
+    private val FITTEXT_FONTSIZE_PRECISION = 0.1f
+
     /**
      * Copied from ColumnText.java in the itextpdf 5.3.0 source code.
      * Added the newlinesAllowed argument.
@@ -112,8 +113,6 @@ object PdfUtil {
      * @param leadingMultiplier leading multiplier between lines
      * @return the calculated font size that makes the text fit
      */
-    private val FITTEXT_FONTSIZE_PRECISION = 0.1f
-
     fun fitText(font: Font, text: String, rect: Rectangle, maxFontSize: Float, newlinesAllowed: Boolean, leadingMultiplier: Float): Float {
         var maxFontSize = maxFontSize
 
@@ -153,6 +152,7 @@ object PdfUtil {
                 break
             }
         }
+        
         return potentialFontSize
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfUtil.kt
@@ -17,19 +17,23 @@ object PdfUtil {
         for (line in lineList) {
             var startIndex = 0
             var endIndex = 0
+
             while (startIndex < line.length) {
                 // Walk forwards until we've grabbed the maximum number of characters
                 // that fit in a line or we've run out of characters.
-                var substringWidth: Float
                 endIndex++
+
                 while (endIndex <= line.length) {
                     val substring = NON_BREAKING_SPACE + line.substring(startIndex, endIndex) + NON_BREAKING_SPACE
-                    substringWidth = font.baseFont.getWidthPoint(substring, font.size)
+                    val substringWidth = font.baseFont.getWidthPoint(substring, font.size)
+
                     if (substringWidth > availableTextWidth) {
                         break
                     }
+
                     endIndex++
                 }
+
                 // endIndex is one past the best fit, so remove one character and it should fit!
                 endIndex--
 
@@ -38,6 +42,7 @@ object PdfUtil {
                 // Any spaces added for padding after a turn are considered part of
                 // that turn because they're actually NON_BREAKING_SPACE, not a ' '.
                 val perfectFitEndIndex = endIndex
+
                 if (endIndex < line.length) {
                     while (true) {
                         if (endIndex < startIndex) {
@@ -51,19 +56,23 @@ object PdfUtil {
                         // Another dirty hack for sq1: turns only line up
                         // nicely if every line starts with a (x,y). We ensure this
                         // by forcing every line to end with a /.
-                        val isSquareOne = line.indexOf('/') >= 0
+                        val isSquareOne = "/" in line
+
                         if (isSquareOne) {
                             val previousCharacter = line[endIndex - 1]
+
                             if (previousCharacter == '/') {
                                 break
                             }
                         } else {
                             val currentCharacter = line[endIndex]
                             val isTurnCharacter = currentCharacter != ' '
+
                             if (!isTurnCharacter) {
                                 break
                             }
                         }
+
                         endIndex--
                     }
                 }
@@ -74,8 +83,9 @@ object PdfUtil {
                 // space as is available on a line.
                 do {
                     substring += NON_BREAKING_SPACE
-                    substringWidth = font.baseFont.getWidthPoint(substring, font.size)
+                    val substringWidth = font.baseFont.getWidthPoint(substring, font.size)
                 } while (substringWidth <= availableTextWidth)
+
                 // substring is now too big for our line, so remove the
                 // last character.
                 substring = substring.substring(0, substring.length - 1)
@@ -85,13 +95,17 @@ object PdfUtil {
                 while (endIndex < line.length && line[endIndex] == ' ') {
                     endIndex++
                 }
-                startIndex = endIndex
-                val lineChunk = Chunk(substring)
-                lineChunks.add(lineChunk)
-                lineChunk.font = font
 
-                // Force a line wrap!
-                lineChunk.append("\n")
+                startIndex = endIndex
+
+                val lineChunk = Chunk(substring).apply {
+                    this.font = font
+
+                    // Force a line wrap!
+                    append("\n")
+                }
+
+                lineChunks.add(lineChunk)
             }
         }
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/StringUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/StringUtil.kt
@@ -34,8 +34,7 @@ object StringUtil {
     }
 
     fun String.toFileSafeString() = filter { it !in INVALID_CHARS }
-
-    fun stripNewlines(strings: List<String>) = strings.map { it.replace("\n", " ") }
+    fun List<String>.stripNewlines() = map { it.replace("\n", " ") }
 
     fun randomPasscode(): String {
         val secureRandom = SecureRandom()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/TableAndHighlighting.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/TableAndHighlighting.kt
@@ -1,5 +1,0 @@
-package org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util
-
-import com.itextpdf.text.pdf.PdfPTable
-
-data class TableAndHighlighting(val table: PdfPTable, val highlighting: Boolean)


### PR DESCRIPTION
Two major goals:
1. Get rid of `var`, because stateful programming is dangerous
2. Get rid of `tableAndHighlighting`, because it can be effectively pre-computed