### PR TITLE
Include SystemTray classes in Gradle minification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,10 @@ tasks.create<ProGuardTask>("generateOfficialRelease") {
 
     keep("class ch.qos.logback.core.FileAppender { *; }")
 
+    keep("class com.sun.jna.** { *; }")
+    keep("class dorkbox.util.jna.** { *; }")
+    keep("class dorkbox.systemTray.** { *; }")
+
     keepclasseswithmembernames("""class * {
         native <methods>;
     }""".trimIndent())


### PR DESCRIPTION
Don't let ProGuard throw away the JNI implementations necessary for showing stuff in the system tray