### PR TITLE
Fix PDF caching, and don't draw on the same canvas twice

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/BasePdfSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/BasePdfSheet.kt
@@ -6,7 +6,7 @@ import com.itextpdf.text.pdf.PdfWriter
 import java.io.ByteArrayOutputStream
 
 abstract class BasePdfSheet<W : PdfWriter>(val title: String?) : PdfContent {
-    abstract val document: Document
+    open fun openDocument() = Document()
 
     private var renderingCache: ByteArray? = null
 
@@ -16,21 +16,23 @@ abstract class BasePdfSheet<W : PdfWriter>(val title: String?) : PdfContent {
 
     private fun directRender(password: String?): ByteArray {
         val pdfBytes = ByteArrayOutputStream()
-        val docWriter = this.document.getWriter(pdfBytes)
+        val pdfDocument = openDocument()
+
+        val docWriter = pdfDocument.getWriter(pdfBytes)
 
         if (password != null) {
             docWriter.setEncryption(password.toByteArray(), password.toByteArray(), PdfWriter.ALLOW_PRINTING, PdfWriter.STANDARD_ENCRYPTION_128)
         }
 
-        document.open()
-        docWriter.writeContents()
-        document.close()
+        pdfDocument.open()
+        docWriter.writeContents(pdfDocument)
+        pdfDocument.close()
 
         return this.finalise(pdfBytes, password)
             .also { if (password == null) renderingCache = it }
     }
 
-    abstract fun W.writeContents()
+    abstract fun W.writeContents(document: Document)
 
     abstract fun Document.getWriter(bytes: ByteArrayOutputStream): W
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/BaseScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/BaseScrambleSheet.kt
@@ -8,7 +8,7 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import java.io.ByteArrayOutputStream
 
 abstract class BaseScrambleSheet(val scrambleRequest: ScrambleRequest, globalTitle: String?) : BasePdfSheet<PdfWriter>(globalTitle) {
-    override val document =
+    override fun openDocument() =
         Document(PAGE_SIZE, 0f, 0f, 75f, 75f).apply {
             addCreationDate()
             addProducer()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/BaseScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/BaseScrambleSheet.kt
@@ -19,7 +19,7 @@ abstract class BaseScrambleSheet(val scrambleRequest: ScrambleRequest, globalTit
         }
 
     override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfWriter {
-        return PdfWriter.getInstance(document, bytes).apply {
+        return PdfWriter.getInstance(this, bytes).apply {
             setBoxSize("art", Rectangle(36f, 54f, PAGE_SIZE.width - 36, PAGE_SIZE.height - 54))
         }
     }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcGenericSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcGenericSolutionSheet.kt
@@ -1,11 +1,12 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.pdf
 
+import com.itextpdf.text.Document
 import com.itextpdf.text.pdf.PdfWriter
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import java.util.*
 
 class FmcGenericSolutionSheet(request: ScrambleRequest, globalTitle: String?, locale: Locale) : FmcSolutionSheet(request, globalTitle, locale) {
-    override fun PdfWriter.writeContents() {
+    override fun PdfWriter.writeContents(document: Document) {
         addFmcSolutionSheet(document, scrambleRequest, title, -1, locale)
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcScrambleCutoutSheet.kt
@@ -1,5 +1,6 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.pdf
 
+import com.itextpdf.text.Document
 import com.itextpdf.text.Element
 import com.itextpdf.text.Image
 import com.itextpdf.text.Rectangle
@@ -12,14 +13,14 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 
 class FmcScrambleCutoutSheet(request: ScrambleRequest, globalTitle: String?): FmcSheet(request, globalTitle) {
-    override fun PdfWriter.writeContents() {
+    override fun PdfWriter.writeContents(document: Document) {
         for (i in scrambleRequest.scrambles.indices) {
-            addFmcScrambleCutoutSheet(scrambleRequest, title, i)
+            addFmcScrambleCutoutSheet(document, scrambleRequest, title, i)
             document.newPage()
         }
     }
 
-    private fun PdfWriter.addFmcScrambleCutoutSheet(scrambleRequest: ScrambleRequest, globalTitle: String?, index: Int) {
+    private fun PdfWriter.addFmcScrambleCutoutSheet(document: Document, scrambleRequest: ScrambleRequest, globalTitle: String?, index: Int) {
         val pageSize = document.pageSize
         val scramble = scrambleRequest.scrambles[index]
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
@@ -18,7 +18,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, locale: Locale) : FmcSheet(request, globalTitle, locale) {
-    override fun PdfWriter.writeContents() {
+    override fun PdfWriter.writeContents(document: Document) {
         for (i in scrambleRequest.scrambles.indices) {
             addFmcSolutionSheet(document, scrambleRequest, title, i, locale)
             document.newPage()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
@@ -18,7 +18,7 @@ import kotlin.math.log10
 import kotlin.math.min
 
 class GeneralScrambleSheet(scrambleRequest: ScrambleRequest, globalTitle: String?) : BaseScrambleSheet(scrambleRequest, globalTitle) {
-    override fun PdfWriter.writeContents() {
+    override fun PdfWriter.writeContents(document: Document) {
         val pageSize = document.pageSize
 
         val sideMargins = 100f + document.leftMargin() + document.rightMargin()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdf.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdf.kt
@@ -7,11 +7,9 @@ import com.itextpdf.text.pdf.PdfWriter
 import java.io.ByteArrayOutputStream
 
 class MergedPdf(val toMerge: List<PdfContent>) : BasePdfSheet<PdfSmartCopy>(null) {
-    override val document = Document()
-
     override fun Document.getWriter(bytes: ByteArrayOutputStream) = PdfSmartCopy(this, bytes)
 
-    override fun PdfSmartCopy.writeContents() {
+    override fun PdfSmartCopy.writeContents(document: Document) {
         for (content in toMerge) {
             val contentReader = PdfReader(content.render())
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdf.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdf.kt
@@ -9,7 +9,7 @@ import java.io.ByteArrayOutputStream
 class MergedPdf(val toMerge: List<PdfContent>) : BasePdfSheet<PdfSmartCopy>(null) {
     override val document = Document()
 
-    override fun Document.getWriter(bytes: ByteArrayOutputStream) = PdfSmartCopy(document, bytes)
+    override fun Document.getWriter(bytes: ByteArrayOutputStream) = PdfSmartCopy(this, bytes)
 
     override fun PdfSmartCopy.writeContents() {
         for (content in toMerge) {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdfWithOutline.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdfWithOutline.kt
@@ -7,7 +7,7 @@ import java.io.ByteArrayOutputStream
 class MergedPdfWithOutline(val toMerge: List<PdfContent>, val configuration: List<Triple<String, String, Int>>, globalTitle: String?) : BasePdfSheet<PdfSmartCopy>(globalTitle) {
     override val document = Document()
 
-    override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfSmartCopy = PdfSmartCopy(document, bytes)
+    override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfSmartCopy = PdfSmartCopy(this, bytes)
 
     override fun PdfSmartCopy.writeContents() {
         val root = directContent.rootOutline

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdfWithOutline.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/MergedPdfWithOutline.kt
@@ -5,11 +5,9 @@ import com.itextpdf.text.pdf.*
 import java.io.ByteArrayOutputStream
 
 class MergedPdfWithOutline(val toMerge: List<PdfContent>, val configuration: List<Triple<String, String, Int>>, globalTitle: String?) : BasePdfSheet<PdfSmartCopy>(globalTitle) {
-    override val document = Document()
-
     override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfSmartCopy = PdfSmartCopy(this, bytes)
 
-    override fun PdfSmartCopy.writeContents() {
+    override fun PdfSmartCopy.writeContents(document: Document) {
         val root = directContent.rootOutline
 
         val outlineByPuzzle = mutableMapOf<String, PdfOutline>()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
@@ -13,7 +13,7 @@ import java.time.LocalDate
 class WatermarkPdfWrapper(val original: PdfContent, val creationTitle: String, val creationDate: LocalDate, val versionTag: String, globalTitle: String?) : BasePdfSheet<PdfWriter>(globalTitle) {
     override val document = Document(PAGE_SIZE, 0f, 0f, 75f, 75f)
 
-    override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfWriter = PdfWriter.getInstance(document, bytes)
+    override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfWriter = PdfWriter.getInstance(this, bytes)
 
     override fun PdfWriter.writeContents() {
         val cb = directContent

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/WatermarkPdfWrapper.kt
@@ -11,11 +11,11 @@ import java.io.ByteArrayOutputStream
 import java.time.LocalDate
 
 class WatermarkPdfWrapper(val original: PdfContent, val creationTitle: String, val creationDate: LocalDate, val versionTag: String, globalTitle: String?) : BasePdfSheet<PdfWriter>(globalTitle) {
-    override val document = Document(PAGE_SIZE, 0f, 0f, 75f, 75f)
+    override fun openDocument() = Document(PAGE_SIZE, 0f, 0f, 75f, 75f)
 
     override fun Document.getWriter(bytes: ByteArrayOutputStream): PdfWriter = PdfWriter.getInstance(this, bytes)
 
-    override fun PdfWriter.writeContents() {
+    override fun PdfWriter.writeContents(document: Document) {
         val cb = directContent
         val pr = PdfReader(original.render())
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/ComputerDisplayZip.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/ComputerDisplayZip.kt
@@ -21,7 +21,7 @@ data class ComputerDisplayZip(val scrambleRequests: List<ScrambleRequest>) {
     fun assemble(globalTitle: String?, generationDate: LocalDate, versionTag: String): ZipArchive {
         return zipArchive {
             for ((uniqueTitle, scrambleRequest) in uniqueTitledRequests) {
-                val computerDisplayPdf = scrambleRequest.createPdf(globalTitle, generationDate, versionTag, Translate.DEFAULT_LOCALE)
+                val computerDisplayPdf = scrambleRequest.getCachedPdf(globalTitle, generationDate, versionTag, Translate.DEFAULT_LOCALE)
 
                 val passcode = passcodes.getValue(uniqueTitle)
                 val computerDisplayBytes = computerDisplayPdf.render(passcode)


### PR DESCRIPTION
Unfortunately, itext5 does not support exporting the same canvas to encryted and unencrypted files. You have to re-draw everything from the ground up to be able to generate encrypted PDFs.

Hopefully migrating to itext7 soon-ish