### PR TITLE
Pre calculate fontSize for all scrambles fix #497

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSolutionSheet.kt
@@ -7,10 +7,10 @@ import com.itextpdf.text.pdf.PdfPTable
 import com.itextpdf.text.pdf.PdfWriter
 import org.worldcubeassociation.tnoodle.server.webscrambles.ScrambleRequest
 import org.worldcubeassociation.tnoodle.server.webscrambles.Translate
-import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.renderSvgToPDF
+import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.fitAndShowText
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.populateRect
-import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.FontUtil
+import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfDrawUtil.renderSvgToPDF
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.PdfUtil
 import java.util.*
 import kotlin.math.ceil
@@ -268,7 +268,7 @@ open class FmcSolutionSheet(request: ScrambleRequest, globalTitle: String?, loca
         val movesFont = Font(bf, movesFontSize.toFloat())
 
         val table = PdfPTable(columns).apply {
-            setTotalWidth(floatArrayOf(firstColumnWidth.toFloat(), *FloatArray(WCA_MOVES.size) { it -> cellWidth.toFloat() }))
+            setTotalWidth(floatArrayOf(firstColumnWidth.toFloat(), *FloatArray(WCA_MOVES.size) { cellWidth.toFloat() }))
             isLockedWidth = true
         }
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/FontUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/FontUtil.kt
@@ -11,7 +11,7 @@ object FontUtil {
     val NOTO_SANS_FONT: BaseFont = BaseFont.createFont("fonts/NotoSans-Regular.ttf", BaseFont.IDENTITY_H, BaseFont.EMBEDDED)
 
     const val MAX_SCRAMBLE_FONT_SIZE = 20f
-    const val MINIMUM_ONE_LINE_FONT_SIZE = 12f
+    const val MINIMUM_ONE_LINE_FONT_SIZE = 15f
 
     private val FONT_BY_LOCALE = mapOf(
         Locale.forLanguageTag("zh-CN") to CJK_FONT,


### PR DESCRIPTION
This a quick fix and is not part of the big refactoring I'm doing #499

@Laura-O 's scrambles should look like this

[Scrambles for Berlin Winter Cubing 2020 - All Scrambles.pdf](https://github.com/thewca/tnoodle/files/4142047/Scrambles.for.Berlin.Winter.Cubing.2020.-.All.Scrambles.pdf)


A complete set of scrambles should look like this

[Scrambles for 2020-01-31 - All Scrambles.pdf](https://github.com/thewca/tnoodle/files/4142030/Scrambles.for.2020-01-31.-.All.Scrambles.pdf)

The fix idea is pretty simple: pre calculate font size using scrambleRequest.allScrambles instead of each part. I also set minimum one line font size to 15 because 12 looked unnecessarily tiny.