### PR TITLE
Strip diacritics from ZIP filenames

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Libraries.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Libraries.kt
@@ -25,6 +25,7 @@ object Libraries {
     val GOOGLE_APPENGINE_GRADLE = "com.google.cloud.tools:appengine-gradle-plugin:${Versions.GOOGLE_APPENGINE_GRADLE}"
     val GOOGLE_CLOUD_STORAGE = "com.google.cloud:google-cloud-storage:${Versions.GOOGLE_CLOUD_STORAGE}"
     val TNOODLE_SCRAMBLES = "org.worldcubeassociation.tnoodle:lib-scrambles:${Versions.TNOODLE_SCRAMBLES}"
+    val APACHE_COMMONS_LANG3 = "org.apache.commons:commons-lang3:${Versions.APACHE_COMMONS_LANG3}"
 
     object Buildscript {
         val PROGUARD_GRADLE_ACTUAL = PROGUARD_GRADLE

--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -8,7 +8,7 @@ object Versions {
     val PROGUARD = "6.2.2"
 
     val MARKDOWNJ_CORE = "0.4"
-    val ZIP4J = "2.2.8"
+    val ZIP4J = "2.3.1"
     val ITEXTPDF = "5.5.13.1"
     val BATIK_TRANSCODER = BATIK
     val SNAKEYAML = "1.25"

--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -31,6 +31,7 @@ object Versions {
     val GOOGLE_APPENGINE_GRADLE = "2.2.0"
     val GOOGLE_CLOUD_STORAGE = "1.103.0"
     val TNOODLE_SCRAMBLES = "0.16.4"
+    val APACHE_COMMONS_LANG3 = "3.9"
 
     object Plugins {
         val SHADOW = "5.2.0"

--- a/webscrambles/build.gradle.kts
+++ b/webscrambles/build.gradle.kts
@@ -6,6 +6,7 @@ import dependencies.Libraries.BATIK_TRANSCODER
 import dependencies.Libraries.BOUNCYCASTLE
 import dependencies.Libraries.ITEXTPDF
 import dependencies.Libraries.KOTLIN_ARGPARSER
+import dependencies.Libraries.APACHE_COMMONS_LANG3
 import dependencies.Libraries.SYSTEM_TRAY
 import dependencies.Libraries.KOTLIN_SERIALIZATION_JVM
 import dependencies.Libraries.SNAKEYAML
@@ -50,6 +51,7 @@ dependencies {
     implementation(SYSTEM_TRAY)
     implementation(TNOODLE_SCRAMBLES)
     implementation(KOTLIN_SERIALIZATION_JVM)
+    implementation(APACHE_COMMONS_LANG3)
 
     runtimeOnly(project(":tnoodle-ui"))
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/model/ZipArchive.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/model/ZipArchive.kt
@@ -5,6 +5,7 @@ import net.lingala.zip4j.model.ZipParameters
 import net.lingala.zip4j.model.enums.CompressionLevel
 import net.lingala.zip4j.model.enums.CompressionMethod
 import net.lingala.zip4j.model.enums.EncryptionMethod
+import org.apache.commons.lang3.StringUtils
 import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.util.StringUtil.toFileSafeString
 import java.io.ByteArrayOutputStream
 
@@ -21,14 +22,13 @@ class ZipArchive(private val entries: List<ZipNode>) {
     fun directCompress(password: String?): ByteArray {
         val baosZip = ByteArrayOutputStream()
 
-        val zipOut = password?.let { ZipOutputStream(baosZip, it.toCharArray()) }
-            ?: ZipOutputStream(baosZip)
+        val zipOut = ZipOutputStream(baosZip, password?.toCharArray())
 
         val usePassword = password != null
         val parameters = defaultZipParameters(usePassword)
 
         for (file in allFiles) {
-            parameters.fileNameInZip = file.path
+            parameters.fileNameInZip = file.path.stripDiacritics()
 
             zipOut.putNextEntry(parameters)
             zipOut.write(file.content)
@@ -43,6 +43,8 @@ class ZipArchive(private val entries: List<ZipNode>) {
     }
 
     companion object {
+        private fun String.stripDiacritics() = StringUtils.stripAccents(this)
+
         private fun defaultZipParameters(useEncryption: Boolean = false) = ZipParameters().apply {
             compressionMethod = CompressionMethod.DEFLATE
             compressionLevel = CompressionLevel.NORMAL


### PR DESCRIPTION
This is the bottom line of a lengthy discussion about ZIP UTF-8 support, cf. https://github.com/srikanth-lingala/zip4j/issues/131