### PR TITLE
Fix polymorphism trouble with Extensions

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/FmcSheet.kt
@@ -8,7 +8,7 @@ import java.util.Locale
 abstract class FmcSheet(scrambleSet: ScrambleSet, activityCode: ActivityCode, val competitionTitle: String, val locale: Locale = Translate.DEFAULT_LOCALE) : BaseScrambleSheet(scrambleSet, activityCode) {
     val expectedAttemptNum: Int
         get() = scrambleSet.findExtension<FmcAttemptCountExtension>()
-            ?.data ?: 1
+            ?.totalAttempts ?: 1
 
     companion object {
         const val WCA_MAX_MOVES_FMC = 80

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/ScrambleDrawingData.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/ScrambleDrawingData.kt
@@ -11,9 +11,9 @@ data class CompetitionDrawingData(val competitionTitle: String, val scrambleShee
 data class ScrambleDrawingData(val scrambleSet: ScrambleSet, val activityCode: ActivityCode) {
     val isFmc: Boolean
         get() = scrambleSet.findExtension<FmcExtension>()
-            ?.data ?: activityCode.eventId == "333fm"
+            ?.isFmc ?: activityCode.eventId == "333fm"
 
     val numCopies: Int
         get() = scrambleSet.findExtension<SheetCopyCountExtension>()
-            ?.data ?: 1
+            ?.numCopies ?: 1
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Extension.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Extension.kt
@@ -2,26 +2,22 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
 
 import kotlinx.serialization.*
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.json
 import org.worldcubeassociation.tnoodle.server.serial.JsonConfig
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.ExtensionBuilder
 
 @Serializable
 data class Extension(val id: String, val specUrl: String, val data: JsonObject) {
+    val jsonObject
+        get() = JsonConfig.SERIALIZER.toJson(serializer(), this).jsonObject
+
     inline fun <reified T : ExtensionBuilder> parsedData(): T? {
         if (id !in ExtensionBuilder.REGISTERED_CHILDREN) {
             return null
         }
 
-        val mockConstruction = json {
-            "id" to id
-            "specUrl" to specUrl
+        val mockData = jsonObject.content - "data" + data.content
+        val mockExtension = JsonObject(mockData)
 
-            for ((k, v) in data) {
-                k to v
-            }
-        }
-
-        return JsonConfig.SERIALIZER.fromJson(ExtensionBuilder.serializer(), mockConstruction) as? T
+        return JsonConfig.SERIALIZER.fromJson(ExtensionBuilder.serializer(), mockExtension) as? T
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Extension.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Extension.kt
@@ -1,0 +1,27 @@
+package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
+
+import kotlinx.serialization.*
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.json
+import org.worldcubeassociation.tnoodle.server.serial.JsonConfig
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.ExtensionBuilder
+
+@Serializable
+data class Extension(val id: String, val specUrl: String, val data: JsonObject) {
+    inline fun <reified T : ExtensionBuilder> parsedData(): T? {
+        if (id !in ExtensionBuilder.REGISTERED_CHILDREN) {
+            return null
+        }
+
+        val mockConstruction = json {
+            "id" to id
+            "specUrl" to specUrl
+
+            for ((k, v) in data) {
+                k to v
+            }
+        }
+
+        return JsonConfig.SERIALIZER.fromJson(ExtensionBuilder.serializer(), mockConstruction) as? T
+    }
+}

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Round.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Round.kt
@@ -1,7 +1,6 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
 
 import kotlinx.serialization.Serializable
-import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.Extension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.ExtensionProvider
 
 @Serializable

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/ScrambleSet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/ScrambleSet.kt
@@ -1,7 +1,6 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
 
 import kotlinx.serialization.Serializable
-import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.Extension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.ExtensionProvider
 
 @Serializable

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/extension/ExtensionBuilders.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/extension/ExtensionBuilders.kt
@@ -2,16 +2,28 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extensio
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.worldcubeassociation.tnoodle.server.serial.JsonConfig
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.Extension
 
 @Serializable
-sealed class Extension(val specUrl: String) {
+sealed class ExtensionBuilder(private val specUrl: String) {
     abstract val id: String
-    abstract val data: Any
+
+    fun build(): Extension {
+        val rawData = JsonConfig.SERIALIZER.toJson(serializer(), this)
+        return Extension(id, specUrl, rawData.jsonObject)
+    }
+
+    companion object {
+        val REGISTERED_CHILDREN = List(serializer().descriptor.elementsCount) {
+            serializer().descriptor.getElementName(it)
+        }
+    }
 }
 
 @Serializable
 @SerialName(FmcExtension.ID)
-data class FmcExtension(override val data: Boolean) : Extension(SPEC_URL) {
+data class FmcExtension(val isFmc: Boolean) : ExtensionBuilder(SPEC_URL) {
     override val id get() = ID
 
     companion object {
@@ -22,7 +34,7 @@ data class FmcExtension(override val data: Boolean) : Extension(SPEC_URL) {
 
 @Serializable
 @SerialName(FmcLanguagesExtension.ID)
-data class FmcLanguagesExtension(override val data: List<String>) : Extension(SPEC_URL) {
+data class FmcLanguagesExtension(val languageTags: List<String>) : ExtensionBuilder(SPEC_URL) {
     override val id get() = ID
 
     companion object {
@@ -33,7 +45,7 @@ data class FmcLanguagesExtension(override val data: List<String>) : Extension(SP
 
 @Serializable
 @SerialName(FmcAttemptCountExtension.ID)
-data class FmcAttemptCountExtension(override val data: Int) : Extension(SPEC_URL) {
+data class FmcAttemptCountExtension(val totalAttempts: Int) : ExtensionBuilder(SPEC_URL) {
     override val id get() = ID
 
     companion object {
@@ -44,7 +56,7 @@ data class FmcAttemptCountExtension(override val data: Int) : Extension(SPEC_URL
 
 @Serializable
 @SerialName(ExtraScrambleCountExtension.ID)
-data class ExtraScrambleCountExtension(override val data: Int) : Extension(SPEC_URL) {
+data class ExtraScrambleCountExtension(val extraAttempts: Int) : ExtensionBuilder(SPEC_URL) {
     override val id get() = ID
 
     companion object {
@@ -55,7 +67,7 @@ data class ExtraScrambleCountExtension(override val data: Int) : Extension(SPEC_
 
 @Serializable
 @SerialName(MultiScrambleCountExtension.ID)
-data class MultiScrambleCountExtension(override val data: Int) : Extension(SPEC_URL) {
+data class MultiScrambleCountExtension(val requestedScrambles: Int) : ExtensionBuilder(SPEC_URL) {
     override val id get() = ID
 
     companion object {
@@ -66,7 +78,7 @@ data class MultiScrambleCountExtension(override val data: Int) : Extension(SPEC_
 
 @Serializable
 @SerialName(SheetCopyCountExtension.ID)
-data class SheetCopyCountExtension(override val data: Int) : Extension(SPEC_URL) {
+data class SheetCopyCountExtension(val numCopies: Int) : ExtensionBuilder(SPEC_URL) {
     override val id get() = ID
 
     companion object {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/folder/PrintingFolder.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/zip/folder/PrintingFolder.kt
@@ -49,7 +49,7 @@ data class PrintingFolder(val uniqueTitles: Map<String, ScrambleDrawingData>, va
 
                         folder("Translations") {
                             val requestedTranslations = req.scrambleSet.findExtension<FmcLanguagesExtension>()
-                                ?.data?.takeUnless { it.isEmpty() } ?: Translate.locales.map { it.toLanguageTag() }
+                                ?.languageTags?.takeUnless { it.isEmpty() } ?: Translate.locales.map { it.toLanguageTag() }
 
                             for (locale in Translate.locales) {
                                 if (locale.toLanguageTag() !in requestedTranslations) {


### PR DESCRIPTION
Typed languages don't like polymorphic concepts like the WCIF `Extension`. We circumvent this fact by parsing into a generic `JsonElement` object and then layering a second `ExtensionBuilder` on top of that.

It's a bit inconvenient, but at least we have control over the meachnism now and foreign extensions don't choke scramble generation anymore.