### PR TITLE
Use tail recursion for binarySearch algorithm

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfDrawUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfDrawUtil.kt
@@ -40,14 +40,11 @@ object PdfDrawUtil {
 
             val parsedSvgDocument = factory.createSVGDocument(null, svg.toString().reader())
 
+            val scaleWidth = dim.width.toDouble() / svg.size.width
+            val scaleHeight = dim.height.toDouble() / svg.size.height
+
             val chartGfx = GVTBuilder().build(ctx, parsedSvgDocument)
-
-            val actualSize = svg.size
-
-            val scaleWidth = dim.width.toDouble() / actualSize.width
-            val scaleHeight = dim.height.toDouble() / actualSize.height
-
-            chartGfx.transform = AffineTransform.getScaleInstance(scaleWidth, scaleHeight)
+                .apply { transform = AffineTransform.getScaleInstance(scaleWidth, scaleHeight) }
 
             chartGfx.paint(g2)
         } finally {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/PdfUtil.kt
@@ -162,13 +162,14 @@ object PdfUtil {
         }
     }
 
-    fun binarySearch(min: Float, max: Float, precision: Float, shouldIncrease: (Float) -> Boolean): Float {
+    tailrec fun binarySearch(min: Float, max: Float, precision: Float, shouldIncrease: (Float) -> Boolean): Float {
+        val potentialFontSize = (min + max) / 2f
+
         if (max - min < precision) {
             // Ground recursion: We have converged arbitrarily close to some target value.
-            return min
+            return potentialFontSize
         }
 
-        val potentialFontSize = (min + max) / 2f
         val iterationShouldIncrease = shouldIncrease(potentialFontSize)
 
         return if (iterationShouldIncrease) {


### PR DESCRIPTION
Shaves off approx. half a second of runtime from PDF rendering