### PR TITLE
Fix errors related to MBLD loading

### DIFF
--- a/tnoodle-ui/src/components/EventPicker.jsx
+++ b/tnoodle-ui/src/components/EventPicker.jsx
@@ -174,6 +174,7 @@ const EventPicker = connect(
                                 </th>
                                 <td className="align-middle">
                                     <select
+                                        value={rounds[i].format}
                                         onChange={evt =>
                                             this.handleRoundFormatChanged(
                                                 i,

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFDataBuilder.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFDataBuilder.kt
@@ -88,8 +88,8 @@ object WCIFDataBuilder {
             val singleSheets = scrambleSet.scrambles.mapIndexed { nthAttempt, scrambleStr ->
                 val scrambles = scrambleStr.allScrambleStrings.map { Scramble(it) }
 
-                // FIXME this feels hacky
-                val pseudoCode = activityCode.copyParts(groupNumber = nthAttempt)
+                // +1 for human readability so the first attempt (index 0) gets printed as "Attempt 1"
+                val pseudoCode = activityCode.copyParts(attemptNumber = nthAttempt + 1)
 
                 val attemptScrambles = scrambleSet.copy(
                     scrambles = scrambles,

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFScrambleMatcher.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFScrambleMatcher.kt
@@ -92,7 +92,7 @@ object WCIFScrambleMatcher {
         val standardScrambleNum = standardScrambleCountPerSet(round)
 
         val scrambles = if (round.idCode.eventPlugin == EventPlugins.THREE_MULTI_BLD) {
-            val countPerAttempt = standardScrambleNum / round.scrambleSetCount
+            val countPerAttempt = standardScrambleNum / round.expectedAttemptNum
 
             List(round.expectedAttemptNum) { _ ->
                 val scrambles = puzzle.generateEfficientScrambles(countPerAttempt) { onUpdate(puzzle, it) }


### PR DESCRIPTION
The UI fix is more general, but it was observed/encountered with Multi because Multi is one of the few events where the event with the most # of attempts is not commonly used at comps.