### PR TITLE
Bump ktor to version 1.3.2

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     val JUNIT_JUPITER = "5.6.0"
     val BATIK = "1.12"
     val KOTLIN = "1.3.70"
-    val KTOR = "1.3.1"
+    val KTOR = "1.3.2"
     val PROGUARD = "6.2.2"
     val KOTLESS = "0.1.3"
 
@@ -21,7 +21,7 @@ object Versions {
     val KOTLIN_STDLIB_JS = KOTLIN
     val KOTLIN_STDLIB_COMMON = KOTLIN
     val KOTLIN_SERIALIZATION_JVM = "0.20.0"
-    val KOTLIN_COROUTINES_CORE = "1.3.3"
+    val KOTLIN_COROUTINES_CORE = "1.3.4"
     val KTOR_SERVER_NETTY = KTOR
     val KTOR_SERVER_SERVLET = KTOR
     val KTOR_SERIALIZATION = KTOR

--- a/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/TNoodleServer.kt
+++ b/server-ktor/src/main/kotlin/org/worldcubeassociation/tnoodle/server/TNoodleServer.kt
@@ -5,7 +5,7 @@ import io.ktor.application.install
 import io.ktor.features.ContentNegotiation
 import io.ktor.features.DefaultHeaders
 import io.ktor.routing.routing
-import io.ktor.serialization.serialization
+import io.ktor.serialization.json
 import io.ktor.server.engine.ShutDownUrl
 import org.worldcubeassociation.tnoodle.server.routing.JsEnvHandler
 import org.worldcubeassociation.tnoodle.server.routing.StylesheetHandler
@@ -33,7 +33,7 @@ class TNoodleServer(val environmentConfig: ServerEnvironmentConfig) : Applicatio
         }
 
         app.install(ContentNegotiation) {
-            serialization(json = JsonConfig.SERIALIZER)
+            json(json = JsonConfig.SERIALIZER)
         }
     }
 


### PR DESCRIPTION
See title. Fixes runtime error with Kotlin 1.3.70

Much needed fix, so will merge as soon as Travis agrees.