### PR TITLE
Fix logo image URL at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="./server-ktor/src/main/resources/icons/tnoodle_logo_1024.png" alt="TNoodle Logo" height="128px"/>
+<img src="./tnoodle-server/src/main/resources/icons/tnoodle_logo_1024.png" alt="TNoodle Logo" height="128px"/>
 
 # TNoodle
 


### PR DESCRIPTION
Not much to this, but I saw it had been done in a past commit and then broken again with the renaming of a directory.  This fixes that.