### PR TITLE
Add rudimentary cache tests

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Libraries.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Libraries.kt
@@ -28,6 +28,7 @@ object Libraries {
     val TNOODLE_SCRAMBLES = "org.worldcubeassociation.tnoodle:lib-scrambles:${Versions.TNOODLE_SCRAMBLES}"
     val APACHE_COMMONS_LANG3 = "org.apache.commons:commons-lang3:${Versions.APACHE_COMMONS_LANG3}"
     val KOTLESS_KTOR = "io.kotless:ktor-lang:${Versions.KOTLESS_KTOR}"
+    val TESTING_MOCKK = "io.mockk:mockk:${Versions.TESTING_MOCKK}"
 
     object Buildscript {
         val PROGUARD_GRADLE_ACTUAL = PROGUARD_GRADLE

--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -35,6 +35,7 @@ object Versions {
     val TNOODLE_SCRAMBLES = "0.18.0"
     val APACHE_COMMONS_LANG3 = "3.10"
     val KOTLESS_KTOR = KOTLESS
+    val TESTING_MOCKK = "1.10.0"
 
     object Plugins {
         val SHADOW = "5.2.0"

--- a/webscrambles/build.gradle.kts
+++ b/webscrambles/build.gradle.kts
@@ -12,6 +12,7 @@ import dependencies.Libraries.KOTLIN_ARGPARSER
 import dependencies.Libraries.MARKDOWNJ_CORE
 import dependencies.Libraries.SNAKEYAML
 import dependencies.Libraries.SYSTEM_TRAY
+import dependencies.Libraries.TESTING_MOCKK
 import dependencies.Libraries.ZIP4J
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -54,6 +55,8 @@ dependencies {
 
     runtimeOnly(BOUNCYCASTLE)
     runtimeOnly(project(":tnoodle-ui"))
+
+    testImplementation(TESTING_MOCKK)
 }
 
 configureJUnit5()

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/ScrambleDrawingData.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/ScrambleDrawingData.kt
@@ -1,10 +1,15 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
 
 import org.worldcubeassociation.tnoodle.server.model.EventData
+import org.worldcubeassociation.tnoodle.server.webscrambles.pdf.*
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.ActivityCode
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.Scramble
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.FmcExtension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.ScrambleSet
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.MultiScrambleCountExtension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.SheetCopyCountExtension
+import java.time.LocalDate
+import java.util.*
 
 // FIXME do we need some kind of "Scrambles for" prefix?
 data class CompetitionDrawingData(val competitionTitle: String, val scrambleSheets: List<ScrambleDrawingData>)
@@ -17,4 +22,44 @@ data class ScrambleDrawingData(val scrambleSet: ScrambleSet, val activityCode: A
     val numCopies: Int
         get() = scrambleSet.findExtension<SheetCopyCountExtension>()
             ?.numCopies ?: 1
+
+    fun createPdf(creationDate: LocalDate, versionTag: String, sheetTitle: String, locale: Locale): PdfContent {
+        // 333mbf is handled pretty specially: each "scramble" is actually a newline separated
+        // list of 333ni scrambles.
+        // If we detect that we're dealing with 333mbf, then we will generate 1 sheet per attempt,
+        // rather than 1 sheet per round (as we do with every other event).
+
+        // for ordered scrambles, we recreate scrambleRequest so it contains only 1 scramble
+        // to fix this, we pass the attempt number
+        if (activityCode.eventModel == EventData.THREE_MULTI_BLD && !scrambleSet.hasExtension<MultiScrambleCountExtension>()) {
+            val singleSheets = scrambleSet.scrambles.mapIndexed { nthAttempt, scrambleStr ->
+                val scrambles = scrambleStr.allScrambleStrings.map { Scramble(it) }
+
+                // +1 for human readability so the first attempt (index 0) gets printed as "Attempt 1"
+                val pseudoCode = activityCode.copyParts(attemptNumber = nthAttempt + 1)
+
+                val attemptScrambles = scrambleSet.copy(
+                    scrambles = scrambles,
+                    extraScrambles = listOf(),
+                    extensions = scrambleSet.withExtensions(FmcExtension(false), MultiScrambleCountExtension(scrambles.size))
+                )
+
+                val attemptRequest = copy(scrambleSet = attemptScrambles, activityCode = pseudoCode)
+                attemptRequest.createPdf(creationDate, versionTag, sheetTitle, locale)
+            }
+
+            return MergedPdf(singleSheets)
+        }
+
+        assert(scrambleSet.scrambles.isNotEmpty())
+
+        if (isFmc) {
+            // We don't watermark the FMC sheets because they already have
+            // the competition name on them. So we encrypt directly.
+            return FmcSolutionSheet(scrambleSet, activityCode, sheetTitle, locale)
+        }
+
+        val genericSheet = GeneralScrambleSheet(scrambleSet, activityCode) // encrypt when watermarking
+        return WatermarkPdfWrapper(genericSheet, activityCode.compileTitleString(), creationDate, versionTag, sheetTitle, isStaging)
+    }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFDataBuilder.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFDataBuilder.kt
@@ -76,46 +76,6 @@ object WCIFDataBuilder {
         return MergedPdfWithOutline(originalPdfs, configurations)
     }
 
-    fun ScrambleDrawingData.createPdf(creationDate: LocalDate, versionTag: String, sheetTitle: String, locale: Locale): PdfContent {
-        // 333mbf is handled pretty specially: each "scramble" is actually a newline separated
-        // list of 333ni scrambles.
-        // If we detect that we're dealing with 333mbf, then we will generate 1 sheet per attempt,
-        // rather than 1 sheet per round (as we do with every other event).
-
-        // for ordered scrambles, we recreate scrambleRequest so it contains only 1 scramble
-        // to fix this, we pass the attempt number
-        if (activityCode.eventModel == EventData.THREE_MULTI_BLD && !scrambleSet.hasExtension<MultiScrambleCountExtension>()) {
-            val singleSheets = scrambleSet.scrambles.mapIndexed { nthAttempt, scrambleStr ->
-                val scrambles = scrambleStr.allScrambleStrings.map { Scramble(it) }
-
-                // +1 for human readability so the first attempt (index 0) gets printed as "Attempt 1"
-                val pseudoCode = activityCode.copyParts(attemptNumber = nthAttempt + 1)
-
-                val attemptScrambles = scrambleSet.copy(
-                    scrambles = scrambles,
-                    extraScrambles = listOf(),
-                    extensions = scrambleSet.withExtensions(FmcExtension(false), MultiScrambleCountExtension(scrambles.size))
-                )
-
-                val attemptRequest = copy(scrambleSet = attemptScrambles, activityCode = pseudoCode)
-                attemptRequest.createPdf(creationDate, versionTag, sheetTitle, locale)
-            }
-
-            return MergedPdf(singleSheets)
-        }
-
-        assert(scrambleSet.scrambles.isNotEmpty())
-
-        if (isFmc) {
-            // We don't watermark the FMC sheets because they already have
-            // the competition name on them. So we encrypt directly.
-            return FmcSolutionSheet(scrambleSet, activityCode, sheetTitle, locale)
-        }
-
-        val genericSheet = GeneralScrambleSheet(scrambleSet, activityCode) // encrypt when watermarking
-        return WatermarkPdfWrapper(genericSheet, activityCode.compileTitleString(), creationDate, versionTag, sheetTitle, isStaging)
-    }
-
     // register in cache to speed up overall generation process
     fun ScrambleDrawingData.getCachedPdf(creationDate: LocalDate, versionTag: String, sheetTitle: String, locale: Locale) =
         PDF_CACHE.getOrPut(this) { createPdf(creationDate, versionTag, sheetTitle, locale) }

--- a/webscrambles/src/test/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WcifDataBuilderTest.kt
+++ b/webscrambles/src/test/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WcifDataBuilderTest.kt
@@ -2,6 +2,7 @@ package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
 
 import io.mockk.spyk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.worldcubeassociation.tnoodle.server.model.EventData
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFDataBuilder.getCachedPdf
@@ -18,10 +19,12 @@ object WcifDataBuilderTest {
     fun testPDFCachingCaches() {
         val scrToDraw = spyk(randomScrambleSet(EventData.THREE))
 
-        scrToDraw.getCachedDummyPdf()
-        scrToDraw.getCachedDummyPdf()
+        val first = scrToDraw.getCachedDummyPdf()
+        val second = scrToDraw.getCachedDummyPdf()
 
         verify(atMost = 1) { scrToDraw.createPdf(any(), any(), any(), any()) }
+
+        Assertions.assertSame(first, second)
     }
 
     @Test
@@ -38,17 +41,20 @@ object WcifDataBuilderTest {
         val deepUpdatedScramble = scrToDraw.copy(scrambleSet = scrToDraw.scrambleSet.copy(scrambles = randomScrambleDrawing.scrambleSet.scrambles))
         val deepScrToDraw = spyk(deepUpdatedScramble)
 
-        scrToDraw.getCachedDummyPdf()
-        shallowScrToDraw.getCachedDummyPdf()
-        deepScrToDraw.getCachedDummyPdf()
+        val firstBase = scrToDraw.getCachedDummyPdf()
+        val shallowPdf = shallowScrToDraw.getCachedDummyPdf()
+        val deepPdf = deepScrToDraw.getCachedDummyPdf()
 
         verify(exactly = 1) { scrToDraw.createPdf(any(), any(), any(), any()) }
         verify(exactly = 1) { shallowScrToDraw.createPdf(any(), any(), any(), any()) }
         verify(exactly = 1) { deepScrToDraw.createPdf(any(), any(), any(), any()) }
 
-        scrToDraw.getCachedDummyPdf()
+        val secondBase = scrToDraw.getCachedDummyPdf()
 
         verify(exactly = 1) { scrToDraw.createPdf(any(), any(), any(), any()) }
+
+        Assertions.assertSame(firstBase, secondBase)
+        Assertions.assertNotSame(shallowPdf, deepPdf)
     }
 
     private fun randomScrambleSet(event: EventData): ScrambleDrawingData {

--- a/webscrambles/src/test/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WcifDataBuilderTest.kt
+++ b/webscrambles/src/test/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WcifDataBuilderTest.kt
@@ -1,0 +1,64 @@
+package org.worldcubeassociation.tnoodle.server.webscrambles.wcif
+
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.worldcubeassociation.tnoodle.server.model.EventData
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.WCIFDataBuilder.getCachedPdf
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.ActivityCode
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.Scramble
+import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.ScrambleSet
+import java.time.LocalDate
+import java.util.*
+
+object WcifDataBuilderTest {
+    val TEST_INSTANCE = LocalDate.now()
+
+    @Test
+    fun testPDFCachingCaches() {
+        val scrToDraw = spyk(randomScrambleSet(EventData.THREE))
+
+        scrToDraw.getCachedDummyPdf()
+        scrToDraw.getCachedDummyPdf()
+
+        verify(atMost = 1) { scrToDraw.createPdf(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun testPDFCachingUpdateScrambleInvalidates() {
+        val scrToDraw = spyk(randomScrambleSet(EventData.TWO))
+
+        scrToDraw.getCachedDummyPdf()
+
+        val randomScrambleDrawing = randomScrambleSet(EventData.TWO)
+
+        val shallowUpdatedScramble = scrToDraw.copy(scrambleSet = randomScrambleDrawing.scrambleSet)
+        val shallowScrToDraw = spyk(shallowUpdatedScramble)
+
+        val deepUpdatedScramble = scrToDraw.copy(scrambleSet = scrToDraw.scrambleSet.copy(scrambles = randomScrambleDrawing.scrambleSet.scrambles))
+        val deepScrToDraw = spyk(deepUpdatedScramble)
+
+        scrToDraw.getCachedDummyPdf()
+        shallowScrToDraw.getCachedDummyPdf()
+        deepScrToDraw.getCachedDummyPdf()
+
+        verify(exactly = 1) { scrToDraw.createPdf(any(), any(), any(), any()) }
+        verify(exactly = 1) { shallowScrToDraw.createPdf(any(), any(), any(), any()) }
+        verify(exactly = 1) { deepScrToDraw.createPdf(any(), any(), any(), any()) }
+
+        scrToDraw.getCachedDummyPdf()
+
+        verify(exactly = 1) { scrToDraw.createPdf(any(), any(), any(), any()) }
+    }
+
+    private fun randomScrambleSet(event: EventData): ScrambleDrawingData {
+        val scrambles = event.scrambler.generateEfficientScrambles(5)
+        val extraScrambles = event.scrambler.generateEfficientScrambles(2)
+
+        val scrSet = ScrambleSet(42, scrambles.map(::Scramble), extraScrambles.map(::Scramble))
+        return ScrambleDrawingData(scrSet, ActivityCode.compile(event, 1, 1))
+    }
+
+    private fun ScrambleDrawingData.getCachedDummyPdf() =
+        getCachedPdf(TEST_INSTANCE, "fooVersion", "fooString", Locale.ENGLISH)
+}


### PR DESCRIPTION
Ensure that PDFs are being rebuilt when scrambles change