### PR TITLE
Force Jest runner to terminate without watch

### DIFF
--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll --watchAll=false",
     "eject": "react-scripts eject",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"


### PR DESCRIPTION
Yes, the double `watchAll` is intentional. See https://github.com/facebook/create-react-app/issues/6899 for details.