### PR TITLE
Manually compensate for broken WCIF schedules

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/ScrambleDrawingData.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/ScrambleDrawingData.kt
@@ -6,7 +6,6 @@ import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.ActivityC
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.Scramble
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.FmcExtension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.ScrambleSet
-import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.TNoodleStatusExtension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.MultiScrambleCountExtension
 import org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model.extension.SheetCopyCountExtension
 import java.time.LocalDate
@@ -61,5 +60,14 @@ data class ScrambleDrawingData(val scrambleSet: ScrambleSet, val activityCode: A
 
         val genericSheet = GeneralScrambleSheet(scrambleSet, activityCode) // encrypt when watermarking
         return WatermarkPdfWrapper(genericSheet, activityCode.compileTitleString(), creationDate, versionTag, sheetTitle, watermark)
+    }
+
+    fun copyForAttempt(attempt: Int): ScrambleDrawingData {
+        val origScrambles = scrambleSet.allScrambles
+        val designatedScramble = origScrambles[attempt - 1]
+
+        val modifiedSet = scrambleSet.copy(scrambles = listOf(designatedScramble))
+
+        return copy(scrambleSet = modifiedSet)
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFScrambleMatcher.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFScrambleMatcher.kt
@@ -254,6 +254,13 @@ object WCIFScrambleMatcher {
             return activity
         }
 
+        val registeredEventIds = events.map { it.id }
+
+        // manually compensating for https://github.com/thewca/worldcubeassociation.org/issues/4653
+        if (activity.activityCode.eventId !in registeredEventIds) {
+            return activity
+        }
+
         val children = activity.childActivities
 
         // we have children that need to be specified!
@@ -289,8 +296,12 @@ object WCIFScrambleMatcher {
             return activity.copy(scrambleSetId = onlyPossibleSet.id)
         }
 
-        val scrambleSet = matchedRound.scrambleSets[actGroup - 1]
+        // manually compensating for https://github.com/thewca/worldcubeassociation.org/issues/4653
+        if (actGroup > matchedRound.scrambleSetCount) {
+            return activity
+        }
 
+        val scrambleSet = matchedRound.scrambleSets[actGroup - 1]
         return activity.copy(scrambleSetId = scrambleSet.id)
     }
 


### PR DESCRIPTION
There are currently some quirks in the WCA website schedule editor which allow for "unintuitive" schedules to be propagated via WCIF:

- There can be an activity that relates to an event not included in the `events` list
- There can be more groups (as child activities) in the schedule than there are scramble sets

At the time of posting this PR, two sample competitions are `SlowDownPerth2020` and `CubingInRanchi2020` respectively.

See https://github.com/thewca/worldcubeassociation.org/issues/4653 and https://github.com/thewca/worldcubeassociation.org/issues/4793 for the details of the underlying issue. This PR will not discuss whether such schedules resulting from these issues are "correct" or not.