### PR TITLE
Fix frontend redirecting to root URL

### DIFF
--- a/tnoodle-ui/src/components/SideBar.jsx
+++ b/tnoodle-ui/src/components/SideBar.jsx
@@ -125,6 +125,14 @@ const SideBar = connect(
             return string + (number > 1 ? "s" : "");
         };
 
+        currentLocationWithoutQuery = () => {
+            return window.location.origin + window.location.pathname;
+        };
+
+        setPageWithoutRedirect = (url) => {
+            window.history.pushState(null, '', url);
+        }
+
         handleManualSelection = () => {
             this.props.updateEditingStatus(false);
             this.props.updateCompetitionId(null);
@@ -229,21 +237,13 @@ const SideBar = connect(
         updateCompetitionIdQueryParam = (competitionId) => {
             var searchParams = new URLSearchParams(window.location.search);
             searchParams.set("competitionId", competitionId);
-            window.history.pushState(
-                {},
-                "",
-                window.location.origin + "?" + searchParams.toString()
-            );
+            this.setPageWithoutRedirect(this.currentLocationWithoutQuery() + "?" + searchParams.toString())
         };
 
         removeCompetitionIdQueryParam = () => {
             var searchParams = new URLSearchParams(window.location.search);
             searchParams.delete("competitionId");
-            window.history.pushState(
-                {},
-                "",
-                window.location.origin + "?" + searchParams.toString()
-            );
+            this.setPageWithoutRedirect(this.currentLocationWithoutQuery() + "?" + searchParams.toString())
         };
 
         setWcif = (wcif) => {


### PR DESCRIPTION
There was a problem that clicking any competition link in the sidebar would redirect you to `localhost:2014?competition=FooBar2020`.
This is because the code was using `window.location.origin`, which does not include the part of the URL after the slash.

This commit aims to fix and unify query parameter modification.