### PR TITLE
Migrate to new ProGuard 7 artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,9 @@ buildscript {
     }
 
     dependencies {
-        classpath(PROGUARD_GRADLE)
+        classpath(PROGUARD_GRADLE) {
+            exclude(group = "com.android.tools.build")
+        }
         classpath(GOOGLE_APPENGINE_GRADLE)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import proguard.gradle.ProGuardTask
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     dependencies {

--- a/buildSrc/src/main/kotlin/dependencies/Libraries.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Libraries.kt
@@ -21,7 +21,7 @@ object Libraries {
     val KTOR_SERVER_HOST_COMMON = "io.ktor:ktor-server-host-common:${Versions.KTOR_SERVER_HOST_COMMON}"
     val LOGBACK_CLASSIC = "ch.qos.logback:logback-classic:${Versions.LOGBACK_CLASSIC}"
     val KOTLIN_ARGPARSER = "com.xenomachina:kotlin-argparser:${Versions.KOTLIN_ARGPARSER}"
-    val PROGUARD_GRADLE = "net.sf.proguard:proguard-gradle:${Versions.PROGUARD_GRADLE}"
+    val PROGUARD_GRADLE = "com.guardsquare:proguard-gradle:${Versions.PROGUARD_GRADLE}"
     val WCA_I18N = "com.github.thewca:wca_i18n:${Versions.WCA_I18N}"
     val GOOGLE_APPENGINE_GRADLE = "com.google.cloud.tools:appengine-gradle-plugin:${Versions.GOOGLE_APPENGINE_GRADLE}"
     val GOOGLE_CLOUD_STORAGE = "com.google.cloud:google-cloud-storage:${Versions.GOOGLE_CLOUD_STORAGE}"

--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     val BATIK = "1.13"
     val KOTLIN = "1.3.72"
     val KTOR = "1.3.2"
-    val PROGUARD = "6.2.2"
+    val PROGUARD = "7.0.0"
     val KOTLESS = "0.1.5"
 
     val MARKDOWNJ_CORE = "0.4"


### PR DESCRIPTION
New major version, finally they aren't publishing under `net.sf` anymore…

I confirmed that the minified JARs still work as expected.