### PR TITLE
Only send base64 through websockets

### DIFF
--- a/tnoodle-server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/crypto/StringEncryption.kt
+++ b/tnoodle-server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/crypto/StringEncryption.kt
@@ -8,13 +8,19 @@ object StringEncryption {
         val contentBytes = unencrypted.toByteArray(SymmetricCipher.CIPHER_CHARSET)
 
         val cipherContent = initedCipher.doFinal(contentBytes)
-        return Base64.getEncoder().encodeToString(cipherContent)
+        return cipherContent.encodeBase64()
     }
 
     fun applyCipherDecrypt(initedCipher: Cipher, encryptedBase64: String): String {
-        val contentBytes = Base64.getDecoder().decode(encryptedBase64)
+        val contentBytes = encryptedBase64.decodeBase64()
 
         val cipherContent = initedCipher.doFinal(contentBytes)
         return cipherContent.toString(SymmetricCipher.CIPHER_CHARSET)
     }
+
+    private val BASE64_DECODER by lazy { Base64.getDecoder() }
+    private val BASE64_ENCODER by lazy { Base64.getEncoder() }
+
+    fun String.decodeBase64(): ByteArray = BASE64_DECODER.decode(this)
+    fun ByteArray.encodeBase64(): String = BASE64_ENCODER.encodeToString(this)
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/job/JobSchedulingHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/job/JobSchedulingHandler.kt
@@ -14,6 +14,7 @@ import io.ktor.websocket.webSocket
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import org.worldcubeassociation.tnoodle.server.RouteHandler
+import org.worldcubeassociation.tnoodle.server.crypto.StringEncryption.encodeBase64
 import org.worldcubeassociation.tnoodle.server.serial.JsonConfig
 
 object JobSchedulingHandler : RouteHandler {
@@ -114,7 +115,7 @@ object JobSchedulingHandler : RouteHandler {
                     val (type, data) = job.channel(request, this)
 
                     val targetMarker = job.getResultMarker(request)
-                    val encodedData = data.toString(Charsets.UTF_8)
+                    val encodedData = data.encodeBase64()
 
                     // signal that the computation result is about to start
                     send(targetMarker)


### PR DESCRIPTION
Because raw UTF-8 bytes over string-based channels are not nice. Neither to the machine, nor to the eye.