### PR TITLE
Fix FMC translation selection in UI

### DIFF
--- a/tnoodle-ui/src/components/FmcTranslationsDetail.jsx
+++ b/tnoodle-ui/src/components/FmcTranslationsDetail.jsx
@@ -35,9 +35,9 @@ const FmcTranslationsDetail = connect(
             this.state = { showTranslations: false };
         }
 
-        handleTranslation = (id) => {
+        handleTranslation = (id, status) => {
             this.props.updateFileZipBlob(null);
-            this.props.updateTranslation(id);
+            this.props.updateTranslation(id, status);
         };
 
         selectAllTranslations = () => {
@@ -141,9 +141,9 @@ const FmcTranslationsDetail = connect(
                                                                         checked={
                                                                             translation.status
                                                                         }
-                                                                        onChange={() =>
+                                                                        onChange={(e) =>
                                                                             this.handleTranslation(
-                                                                                translation.id
+                                                                                translation.id, e.target.checked
                                                                             )
                                                                         }
                                                                     />

--- a/tnoodle-ui/src/components/Main.jsx
+++ b/tnoodle-ui/src/components/Main.jsx
@@ -16,6 +16,7 @@ const mapStateToProps = (store) => ({
     competitionId: store.competitionId,
     officialZip: store.officialZip,
     fileZipBlob: store.fileZipBlob,
+    translations: store.translations,
 });
 
 const mapDispatchToProps = {

--- a/tnoodle-ui/src/redux/ActionCreators.js
+++ b/tnoodle-ui/src/redux/ActionCreators.js
@@ -80,9 +80,9 @@ export const updateTranslations = (translations) => ({
     payload: { translations },
 });
 
-export const updateTranslation = (id) => ({
+export const updateTranslation = (id, status) => ({
     type: ActionTypes.UPDATE_TRANSLATION,
-    payload: { id },
+    payload: { id, status },
 });
 
 export const resetTranslations = () => ({

--- a/tnoodle-ui/src/redux/Reducers.js
+++ b/tnoodle-ui/src/redux/Reducers.js
@@ -155,7 +155,7 @@ export const Reducer = (store, action) => {
                     ...translation,
                     status:
                         translation.id === action.payload.id
-                            ? !translation.status
+                            ? action.payload.status
                             : translation.status,
                 })),
             ],


### PR DESCRIPTION
The actual fix is contained in https://github.com/thewca/tnoodle/commit/62418c948edeefe3d71cdb79a71411e35440192a

When investigating the problem, I also realised that the current reducers update translations by inverting the current `status` boolean whenever a checkbox is clicked. This may be problematic when the checkbox value and the translation status get out of sync.