### PR TITLE
Hotfix for Turkish installations

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Gender.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/Gender.kt
@@ -1,6 +1,7 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
 
 import org.worldcubeassociation.tnoodle.server.serial.SingletonStringEncoder
+import org.worldcubeassociation.tnoodle.server.webscrambles.exceptions.BadWcifParameterException
 
 enum class Gender(val wcaString: String) {
     MALE("m"),
@@ -11,6 +12,7 @@ enum class Gender(val wcaString: String) {
         fun fromWCAString(wcaString: String) = values().find { it.wcaString == wcaString }
 
         override fun encodeInstance(instance: Gender) = instance.wcaString
-        override fun makeInstance(deserialized: String) = fromWCAString(deserialized)!!
+        override fun makeInstance(deserialized: String) = fromWCAString(deserialized)
+            ?: BadWcifParameterException.error("Unknown WCIF spec Gender: '$deserialized'. Valid types: ${values().map { it.wcaString }}")
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/RegistrationStatus.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/RegistrationStatus.kt
@@ -1,19 +1,18 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
 
 import org.worldcubeassociation.tnoodle.server.serial.SingletonStringEncoder
+import org.worldcubeassociation.tnoodle.server.webscrambles.exceptions.BadWcifParameterException
 
-enum class RegistrationStatus {
-    ACCEPTED,
-    PENDING,
-    DELETED;
-
-    val wcaString
-        get() = name.toLowerCase()
+enum class RegistrationStatus(val wcaString: String) {
+    ACCEPTED("accepted"),
+    PENDING("pending"),
+    DELETED("deleted");
 
     companion object : SingletonStringEncoder<RegistrationStatus>("RegistrationStatus") {
         fun fromWCAString(wcaString: String) = values().find { it.wcaString == wcaString }
 
         override fun encodeInstance(instance: RegistrationStatus) = instance.wcaString
-        override fun makeInstance(deserialized: String) = fromWCAString(deserialized)!!
+        override fun makeInstance(deserialized: String) = fromWCAString(deserialized)
+            ?: BadWcifParameterException.error("Unknown WCIF spec RegistrationStatus: '$deserialized'. Valid types: ${values().map { it.wcaString }}")
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/ResultType.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/model/ResultType.kt
@@ -1,18 +1,17 @@
 package org.worldcubeassociation.tnoodle.server.webscrambles.wcif.model
 
 import org.worldcubeassociation.tnoodle.server.serial.SingletonStringEncoder
+import org.worldcubeassociation.tnoodle.server.webscrambles.exceptions.BadWcifParameterException
 
-enum class ResultType {
-    SINGLE,
-    AVERAGE;
-
-    val wcaString
-        get() = this.name.toLowerCase()
+enum class ResultType(val wcaString: String) {
+    SINGLE("single"),
+    AVERAGE("average");
 
     companion object : SingletonStringEncoder<ResultType>("ResultType") {
         fun fromWCAString(wcaString: String) = values().find { it.wcaString == wcaString }
 
         override fun encodeInstance(instance: ResultType) = instance.wcaString
-        override fun makeInstance(deserialized: String) = fromWCAString(deserialized)!!
+        override fun makeInstance(deserialized: String) = fromWCAString(deserialized)
+            ?: BadWcifParameterException.error("Unknown WCIF spec ResultType: '$deserialized'. Valid types: ${values().map { it.wcaString }}")
     }
 }


### PR DESCRIPTION
Conversion between I and i (lowercase and uppercase letter that comes between H and J) is messed up because Turkish uses an additional I without dot