### PR TITLE
Fix websocket error handling

### DIFF
--- a/tnoodle-ui/src/main/api/tnoodle.api.js
+++ b/tnoodle-ui/src/main/api/tnoodle.api.js
@@ -28,8 +28,7 @@ export const fetchZip = (
 
     return scrambleClient
         .loadScrambles(zipEndpoint, payload, wcif.id)
-        .then((result) => convertToBlob(result))
-        .catch((error) => console.error(error));
+        .then((result) => convertToBlob(result));
 };
 
 const convertToBlob = async (result) => {

--- a/tnoodle-ui/src/main/components/Main.jsx
+++ b/tnoodle-ui/src/main/components/Main.jsx
@@ -46,6 +46,8 @@ const Main = connect(
             this.state = {
                 competitionNameFileZip: "",
             };
+
+            this.interceptor = React.createRef();
         }
         onSubmit = (evt) => {
             evt.preventDefault();
@@ -77,11 +79,17 @@ const Main = connect(
                 this.props.mbld,
                 this.props.password,
                 this.props.translations
-            ).then((blob) => {
-                this.props.updateFileZipBlob(blob);
-                this.props.updateGeneratingScrambles(false);
-                this.props.resetScramblingProgressCurrent();
-            });
+            )
+                .then((blob) => {
+                    this.props.updateFileZipBlob(blob);
+                })
+                .catch((err) => {
+                    this.interceptor.current.updateMessage(err);
+                })
+                .finally(() => {
+                    this.props.updateGeneratingScrambles(false);
+                    this.props.resetScramblingProgressCurrent();
+                });
             this.props.updateGeneratingScrambles(true);
         };
 
@@ -160,7 +168,7 @@ const Main = connect(
             return (
                 <form onSubmit={this.onSubmit}>
                     <div className="sticky-top bg-light">
-                        <Interceptor />
+                        <Interceptor ref={this.interceptor} />
                         <VersionInfo />
                         <div className="container-fluid pt-2">
                             <div className="row">

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/WcifHandler.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/routing/WcifHandler.kt
@@ -51,8 +51,8 @@ class WcifHandler(val environmentConfig: ServerEnvironmentConfig) : RouteHandler
         }
 
         override suspend fun ScramblingJobData.compute(statusBackend: StatusBackend): Pair<ContentType, ByteArray> {
-            val wcif = WCIFScrambleMatcher.fillScrambleSetsAsync(request.extendedWcif) { pzl, _ ->
-                statusBackend.onProgress(pzl.key)
+            val wcif = WCIFScrambleMatcher.fillScrambleSetsAsync(request.extendedWcif) { evt, _ ->
+                statusBackend.onProgress(evt.key)
             }
 
             return scrambledToResult(this, wcif, statusBackend)


### PR DESCRIPTION
The `fetch-intercept` module does not cover websockets, so I decided to process websocket errors manually and then "inject" them into the interceptor.

Feels a little bit nasty to do this with React.Ref(), is there any smarter way?