### PR TITLE
Collapsing side bar

### DIFF
--- a/tnoodle-ui/src/App.css
+++ b/tnoodle-ui/src/App.css
@@ -59,6 +59,18 @@ nav li {
     padding-top: 10px;
 }
 
-#side-bar {
-    height: 100vh;
+@media (min-width: 992px) {
+    #side-bar {
+        height: 100vh;
+        position: sticky;
+        top: 0;
+        z-index: 1020;
+    }
+}
+
+@media (max-width: 991.98px) {
+    #title {
+        margin-bottom: 0;
+        margin-left: 12px;
+    }
 }

--- a/tnoodle-ui/src/App.js
+++ b/tnoodle-ui/src/App.js
@@ -10,12 +10,12 @@ class App extends Component {
             <div className="App container-fluid">
                 <div className="row">
                     <div
-                        className="col-3 bg-dark sticky-top overflow-auto"
+                        className="col-lg-3 bg-dark overflow-auto"
                         id="side-bar"
                     >
                         <SideBar />
                     </div>
-                    <div className="col-9 m-0 p-0">
+                    <div className="col-lg-9 m-0 p-0">
                         <Main />
                     </div>
                 </div>

--- a/tnoodle-ui/src/main/components/SideBar.jsx
+++ b/tnoodle-ui/src/main/components/SideBar.jsx
@@ -119,11 +119,7 @@ const SideBar = connect(
         }
 
         setIsOpen = () => {
-            if (window.innerWidth <= 992) {
-                this.setState({ isOpen: false });
-            } else {
-                this.setState({ isOpen: true });
-            }
+            this.setState({ isOpen: window.innerWidth > 992 });
         };
 
         setLoadingUser = (flag) => {

--- a/tnoodle-ui/src/main/components/SideBar.jsx
+++ b/tnoodle-ui/src/main/components/SideBar.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import Loading from "./Loading";
+import { Collapse } from "react-bootstrap";
 import {
     updateWcif,
     updateEditingStatus,
@@ -67,6 +68,7 @@ const SideBar = connect(
                 loadingCompetitions: false,
                 loadingCompetitionInformation: false,
                 competitionId: null,
+                isOpen: true,
             };
         }
         margin = 1; // Margin for login button and "Manual Selection"
@@ -107,7 +109,22 @@ const SideBar = connect(
             if (competitionId != null) {
                 this.handleCompetitionSelection(competitionId);
             }
+
+            this.setIsOpen();
+            window.addEventListener("resize", this.setIsOpen);
         }
+
+        componentWillUnmount() {
+            window.removeEventListener("resize", this.setIsOpen);
+        }
+
+        setIsOpen = () => {
+            if (window.innerWidth <= 992) {
+                this.setState({ isOpen: false });
+            } else {
+                this.setState({ isOpen: true });
+            }
+        };
 
         setLoadingUser = (flag) => {
             this.setState({ ...this.state, loadingUser: flag });
@@ -337,59 +354,103 @@ const SideBar = connect(
 
         render() {
             return (
-                <div className="h-100">
-                    <img
-                        className="tnoodle-logo mt-2"
-                        src={require("../assets/tnoodle_logo.svg")}
-                        alt="TNoodle logo"
-                    />
-                    <h1 className="display-3" id="title">
-                        TNoodle
-                    </h1>
-                    <div>
-                        <ul className="list-group">
-                            <li>
-                                {(this.state.competitions != null &&
-                                    this.state.competitions.length) > 0 && (
-                                    <button
-                                        type="button"
-                                        className={`btn btn-primary btn-lg btn-block btn-outline-light mb-${this.margin}`}
-                                        onClick={this.handleManualSelection}
-                                        disabled={
-                                            this.props.generatingScrambles
-                                        }
-                                    >
-                                        Manual Selection
-                                    </button>
-                                )}
-                            </li>
-                            {this.state.competitions != null &&
-                                this.state.competitions.map(
-                                    (competition, i) => (
-                                        <li key={i}>
-                                            <button
-                                                type="button"
-                                                className="btn btn-primary btn-lg btn-block m-1"
-                                                disabled={
-                                                    this.props
-                                                        .generatingScrambles
-                                                }
-                                                onClick={(_) =>
-                                                    this.handleCompetitionSelection(
-                                                        competition.id
-                                                    )
-                                                }
-                                            >
-                                                {competition.name}
-                                            </button>
-                                        </li>
-                                    )
-                                )}
-                        </ul>
-
-                        {this.loadingArea()}
+                <div className="h-100 pb-2">
+                    <div className="d-lg-none d-flex align-items-center pt-2 overflow-hidden">
+                        <img
+                            src={require("../assets/tnoodle_logo.svg")}
+                            alt="TNoodle logo"
+                        />
+                        <h1 className="display-3" id="title">
+                            TNoodle
+                        </h1>
+                        <button
+                            type="button"
+                            className="btn btn-primary btn-lg btn-outline-light ml-auto"
+                            onClick={() =>
+                                this.setState({ isOpen: !this.state.isOpen })
+                            }
+                            disabled={this.props.generatingScrambles}
+                            aria-label="Toggle menu"
+                            aria-expanded={this.state.isOpen}
+                        >
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 30 30"
+                                width={30}
+                                height={30}
+                            >
+                                <path
+                                    stroke="currentColor"
+                                    strokeWidth={2}
+                                    strokeLinecap="round"
+                                    strokeMiterlimit={10}
+                                    d="M4 7h22M4 15h22M4 23h22"
+                                />
+                            </svg>
+                        </button>
                     </div>
-                    {this.logInButton()}
+                    <Collapse in={this.state.isOpen}>
+                        <div className="pt-2" id="sidebar-buttons">
+                            <div className="d-none d-lg-block">
+                                <img
+                                    className="tnoodle-logo mt-2"
+                                    src={require("../assets/tnoodle_logo.svg")}
+                                    alt="TNoodle logo"
+                                />
+                                <h1 className="display-3" id="title">
+                                    TNoodle
+                                </h1>
+                            </div>
+                            <div>
+                                <ul className="list-group">
+                                    <li>
+                                        {this.state.competitions != null &&
+                                            this.state.competitions.length >
+                                                0 && (
+                                                <button
+                                                    type="button"
+                                                    className={`btn btn-primary btn-lg btn-block btn-outline-light mb-${this.margin}`}
+                                                    onClick={
+                                                        this
+                                                            .handleManualSelection
+                                                    }
+                                                    disabled={
+                                                        this.props
+                                                            .generatingScrambles
+                                                    }
+                                                >
+                                                    Manual Selection
+                                                </button>
+                                            )}
+                                    </li>
+                                    {this.state.competitions != null &&
+                                        this.state.competitions.map(
+                                            (competition, i) => (
+                                                <li key={i}>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-primary btn-lg btn-block m-1"
+                                                        disabled={
+                                                            this.props
+                                                                .generatingScrambles
+                                                        }
+                                                        onClick={(_) =>
+                                                            this.handleCompetitionSelection(
+                                                                competition.id
+                                                            )
+                                                        }
+                                                    >
+                                                        {competition.name}
+                                                    </button>
+                                                </li>
+                                            )
+                                        )}
+                                </ul>
+                                {this.loadingArea()}
+                            </div>
+                            {this.logInButton()}
+                        </div>
+                    </Collapse>
                 </div>
             );
         }

--- a/tnoodle-ui/src/main/components/SideBar.jsx
+++ b/tnoodle-ui/src/main/components/SideBar.jsx
@@ -351,8 +351,9 @@ const SideBar = connect(
         render() {
             return (
                 <div className="h-100 pb-2">
-                    <div className="d-lg-none d-flex align-items-center pt-2 overflow-hidden">
+                    <div className="d-flex flex-lg-column align-items-center overflow-hidden">
                         <img
+                            className="tnoodle-logo mt-2"
                             src={require("../assets/tnoodle_logo.svg")}
                             alt="TNoodle logo"
                         />
@@ -361,7 +362,7 @@ const SideBar = connect(
                         </h1>
                         <button
                             type="button"
-                            className="btn btn-primary btn-lg btn-outline-light ml-auto"
+                            className="btn btn-primary btn-lg btn-outline-light ml-auto d-lg-none"
                             onClick={() =>
                                 this.setState({ isOpen: !this.state.isOpen })
                             }
@@ -386,17 +387,7 @@ const SideBar = connect(
                         </button>
                     </div>
                     <Collapse in={this.state.isOpen}>
-                        <div className="pt-2" id="sidebar-buttons">
-                            <div className="d-none d-lg-block">
-                                <img
-                                    className="tnoodle-logo mt-2"
-                                    src={require("../assets/tnoodle_logo.svg")}
-                                    alt="TNoodle logo"
-                                />
-                                <h1 className="display-3" id="title">
-                                    TNoodle
-                                </h1>
-                            </div>
+                        <div className="pt-2">
                             <div>
                                 <ul className="list-group">
                                     <li>

--- a/tnoodle-ui/src/test/SideBar.test.js
+++ b/tnoodle-ui/src/test/SideBar.test.js
@@ -49,15 +49,20 @@ it("Each competition fetched from the website must become a button", async () =>
 
     const buttons = Array.from(container.querySelectorAll("button"));
 
-    // First button should be manual selection
-    expect(buttons[0].innerHTML).toBe("Manual Selection");
+    // First button should be svg icon
+    expect(buttons[0].innerHTML).toBe(
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30" height="30"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"></path></svg>`
+    );
+
+    // Second button should be manual selection
+    expect(buttons[1].innerHTML).toBe("Manual Selection");
 
     // Last button should be Log Out
     expect(buttons[buttons.length - 1].innerHTML).toBe("Log Out");
 
     // Each competition must have a button
     for (let i = 0; i < competitions.length; i++) {
-        expect(competitions[i].name).toBe(buttons[i + 1].innerHTML);
+        expect(competitions[i].name).toBe(buttons[i + 2].innerHTML);
     }
 
     // We should welcome the user

--- a/tnoodle-ui/src/test/SideBar.test.js
+++ b/tnoodle-ui/src/test/SideBar.test.js
@@ -49,7 +49,7 @@ it("Each competition fetched from the website must become a button", async () =>
 
     const buttons = Array.from(container.querySelectorAll("button"));
 
-    // First button should be svg icon
+    // First button should be the collapse button
     expect(buttons[0].innerHTML).toBe(
         `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30" height="30"><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"></path></svg>`
     );


### PR DESCRIPTION
Resolves #623.

When screen width is less than 992px, the side bar collapses and is placed at the top of the screen:
<img src=https://user-images.githubusercontent.com/48423418/103076742-6f552d80-459c-11eb-91ff-ad14211cbde5.png width=650px>

Clicking the toggle button reveals the log in, competition and manual selection buttons:
<img src=https://user-images.githubusercontent.com/48423418/103076741-6ebc9700-459c-11eb-94d1-66b26cbb6f3f.png width=650px>

First time contributing in this repo - please let me know if there's any suggestions :)