### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,9 @@ tasks.create("registerReleaseTag") {
 
     outputs.file(signatureStorage)
 
+    // prevent caching this task, so that it always runs no matter what
+    outputs.upToDateWhen { false }
+
     doFirst {
         val privateKeyPath = project.findProperty("wca.wst.signature-private-key")?.toString()
             ?: error("You have to provide a path to a PKCS8 private key for official releases!")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ tasks.create<ProGuardTask>("minifyRelease") {
     val targetConfigurations = project(":$releaseProject").configurations
     libraryjars(targetConfigurations.findByName("runtimeClasspath")?.files)
 
-    printmapping("$buildDir/minified/proguard.map")
+    printmapping("$buildDir/proguard.map")
 }
 
 tasks.create("buildOfficial") {

--- a/buildSrc/src/main/kotlin/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Versions.kt
@@ -14,7 +14,7 @@ object Versions {
     val BATIK_TRANSCODER = BATIK
     val BATIK_CODEC = BATIK
     val SNAKEYAML = "1.28"
-    val SYSTEM_TRAY = "3.17"
+    val SYSTEM_TRAY = "4.1"
     val BOUNCYCASTLE = "1.68"
     val JUNIT_JUPITER_API = JUNIT_JUPITER
     val JUNIT_JUPITER_ENGINE = JUNIT_JUPITER

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -21,7 +21,7 @@
 -keep class ch.qos.logback.core.** { *; }
 
 -keep class com.sun.jna.** { *; }
--keep class dorkbox.util.jna.** { *; }
+-keep class dorkbox.jna.** { *; }
 -keep class dorkbox.systemTray.** { *; }
 
 -keep,includedescriptorclasses class kotlinx.serialization.json.**$$serializer { *; }


### PR DESCRIPTION
Most notably, migrate to SystemTray 4.1 which prevents the ugly "illegal reflective access" warning when adding the tray image