### PR TITLE
Clean up dev dependencies

### DIFF
--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -15,7 +15,6 @@
         "react-icons": "^4.3.1",
         "react-redux": "^7.2.6",
         "react-scripts": "5.0.0",
-        "typescript": "^4.5.5",
         "web-vitals": "^2.1.4"
     },
     "scripts": {
@@ -63,6 +62,7 @@
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
-        "prettier": "^2.5.1"
+        "prettier": "^2.5.1",
+        "typescript": "^4.5.5"
     }
 }

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.4.1",
@@ -63,6 +62,7 @@
         ]
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "^5.16.2",
         "@types/lodash": "^4.14.178",
         "prettier": "^2.5.1"
     }

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.21",
@@ -63,6 +62,7 @@
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^5.16.2",
+        "@testing-library/react": "^12.1.3",
         "@types/lodash": "^4.14.178",
         "prettier": "^2.5.1"
     }

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
         "axios": "^0.26.0",
@@ -63,6 +62,7 @@
         "@testing-library/react": "^12.1.3",
         "@types/jest": "^27.4.1",
         "@types/lodash": "^4.14.178",
+        "@types/node": "^17.0.21",
         "prettier": "^2.5.1"
     }
 }

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@types/react-dom": "^17.0.11",
         "axios": "^0.26.0",
         "bootstrap": "^4.6.0",
         "lodash": "^4.17.21",
@@ -63,6 +62,7 @@
         "@types/lodash": "^4.14.178",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
+        "@types/react-dom": "^17.0.11",
         "prettier": "^2.5.1"
     }
 }

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@types/jest": "^27.4.1",
         "@types/node": "^17.0.21",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
@@ -62,6 +61,7 @@
     "devDependencies": {
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
+        "@types/jest": "^27.4.1",
         "@types/lodash": "^4.14.178",
         "prettier": "^2.5.1"
     }

--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -6,7 +6,6 @@
     "dependencies": {
         "@cubing/icons": "^1.0.6",
         "@reduxjs/toolkit": "^1.8.0",
-        "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
         "axios": "^0.26.0",
         "bootstrap": "^4.6.0",
@@ -63,6 +62,7 @@
         "@types/jest": "^27.4.1",
         "@types/lodash": "^4.14.178",
         "@types/node": "^17.0.21",
+        "@types/react": "^17.0.39",
         "prettier": "^2.5.1"
     }
 }

--- a/tnoodle-ui/yarn.lock
+++ b/tnoodle-ui/yarn.lock
@@ -2386,9 +2386,9 @@
     redent "^3.0.0"
 
 "@testing-library/react@^12.1.3":
-  version "12.1.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.3.tgz#ef26c5f122661ea9b6f672b23dc6b328cadbbf26"
-  integrity sha512-oCULRXWRrBtC9m6G/WohPo1GLcLesH7T4fuKzRAKn1CWVu9BzXtqLXDDTA6KhFNNtRwLtfSMr20HFl+Qrdrvmg==
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.4.tgz#09674b117e550af713db3f4ec4c0942aa8bbf2c0"
+  integrity sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
@@ -2412,9 +2412,9 @@
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
 "@types/aria-query@^4.2.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
-  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0":
   version "7.1.14"
@@ -2667,7 +2667,14 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*", "@types/react-dom@^17.0.11":
+"@types/react-dom@*":
+  version "17.0.13"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
+  integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@^17.0.11":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
   integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
@@ -4466,15 +4473,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6:
+dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
   integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
-
-dom-accessibility-api@^0.5.9:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz#79d5846c4f90eba3e617d9031e921de9324f84ed"
-  integrity sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==
 
 dom-converter@^0.2.0:
   version "0.2.0"

--- a/tnoodle-ui/yarn.lock
+++ b/tnoodle-ui/yarn.lock
@@ -9467,9 +9467,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@^4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 unbox-primitive@^1.0.0, unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/tnoodle-ui/yarn.lock
+++ b/tnoodle-ui/yarn.lock
@@ -2691,10 +2691,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11", "@types/react@^17.0.39":
+"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11":
   version "17.0.39"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
   integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.39":
+  version "17.0.40"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.40.tgz#dc010cee6254d5239a138083f3799a16638e6bad"
+  integrity sha512-UrXhD/JyLH+W70nNSufXqMZNuUD2cXHu6UjCllC6pmOQgBX4SGXOH8fjRka0O0Ee0HrFxapDD8Bwn81Kmiz6jQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/tnoodle-ui/yarn.lock
+++ b/tnoodle-ui/yarn.lock
@@ -2660,17 +2660,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*":
+"@types/react-dom@*", "@types/react-dom@^17.0.11":
   version "17.0.13"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz#a3323b974ee4280070982b3112351bb1952a7809"
   integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^17.0.11":
-  version "17.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
-  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
   dependencies:
     "@types/react" "*"
 

--- a/tnoodle-ui/yarn.lock
+++ b/tnoodle-ui/yarn.lock
@@ -2394,13 +2394,6 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "*"
 
-"@testing-library/user-event@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"

--- a/tnoodle-ui/yarn.lock
+++ b/tnoodle-ui/yarn.lock
@@ -2745,9 +2745,9 @@
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
 "@types/testing-library__jest-dom@^5.9.1":
-  version "5.9.5"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
-  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  version "5.14.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz#ee6c7ffe9f8595882ee7bda8af33ae7b8789ef17"
+  integrity sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==
   dependencies:
     "@types/jest" "*"
 
@@ -4466,7 +4466,12 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
+dom-accessibility-api@^0.5.6:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz#102ee5f25eacce09bdf1cfa5a298f86da473be4b"
+  integrity sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==
+
+dom-accessibility-api@^0.5.9:
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.11.tgz#79d5846c4f90eba3e617d9031e921de9324f84ed"
   integrity sha512-7X6GvzjYf4yTdRKuCVScV+aA9Fvh5r8WzWrXBH9w82ZWB/eYDMGCnazoC/YAqAzUJWHzLOnZqr46K3iEyUhUvw==


### PR DESCRIPTION
Each commit moves a single dev dependency from the `dependencies` section of the `package.json` file to the `devDependencies` section by running `yarn remove <dev dependency>` followed by  `yarn add <dev dependency@version> --dev`.

One exception: https://github.com/thewca/tnoodle/commit/abb2c89dfb65900bb7348d441bd8ea17cc90a06b _removes_ the unused dependency `@testing-library/user-event`.