### PR TITLE
Remove conflicting --watchAll flag from test script

### DIFF
--- a/tnoodle-ui/package.json
+++ b/tnoodle-ui/package.json
@@ -28,7 +28,7 @@
     "scripts": {
         "start": "react-scripts start",
         "build": "react-scripts build",
-        "test": "react-scripts test --watchAll --watchAll=false --coverage",
+        "test": "react-scripts test --watchAll=false --coverage",
         "eject": "react-scripts eject",
         "prettier": "prettier --check .",
         "lint": "prettier --write ."


### PR DESCRIPTION
The test script includes the Jest CLI flag `--watchAll` _and_ `--watchAll=false`.

Experimentally, I've confirmed that the `--watchAll=false` is taking priority, so `--watchAll` has been removed.