### PR TITLE
Fix rendering in Square-1 PDF

### DIFF
--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/GeneralScrambleSheet.kt
@@ -76,7 +76,14 @@ class GeneralScrambleSheet(
                     background = SCRAMBLE_BACKGROUND_COLOR
                     padding = DEFAULT_CELL_PADDING
 
+                    horizontalAlignment = Alignment.Horizontal.CENTER
+                    verticalAlignment = Alignment.Vertical.MIDDLE
+
                     val paddingBackoff = paddingBackoff(DEFAULT_CELL_PADDING)
+
+                    // round DOWN the minHeight by coercing to float. Also, iText 7 does NOT count the padding to the
+                    // cell height, so we additionally have to subtract it (including the backoff) from the height ourselves.
+                    minHeight = (scrLineHeight * unitToInches).inchesToPixel.toFloat() - paddingBackoff
 
                     val scrImageWidthPx = (scrImageWidth * unitToInches).inchesToPixel - paddingBackoff
                     val scrLineHeightPx = (scrLineHeight * unitToInches).inchesToPixel - paddingBackoff

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/ScrambleSheet.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/ScrambleSheet.kt
@@ -53,8 +53,6 @@ abstract class ScrambleSheet(
     }
 
     companion object {
-        val RENDERING_ENGINE = Document.DEFAULT_ENGINE
-
         // fitting stuff into padded boxes doesn't work the way I thought it would.
         fun paddingBackoff(padding: Int): Int {
             // `2 * padding` is the intuitive part. (horizontal: left AND right, vertical: top AND bottom)

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/engine/IText5Engine.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/engine/IText5Engine.kt
@@ -250,6 +250,7 @@ object IText5Engine {
         itextCell.horizontalAlignment = convertAlignment(cell.horizontalAlignment)
         itextCell.border = convertBorder(cell.border)
         itextCell.setPadding(cell.padding.toFloat())
+        cell.minHeight?.let { itextCell.minimumHeight = it }
 
         val renderedContent = render(cell.content.innerElement, cb, fontIndex)
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/engine/IText7Engine.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/engine/IText7Engine.kt
@@ -291,6 +291,7 @@ object IText7Engine {
         itextCell.setBorderAround(borderType, cell.border)
         itextCell.setPadding(cell.padding.toFloat())
         itextCell.setTextAlignment(convertTextAlignment(cell.horizontalAlignment))
+        cell.minHeight?.let { itextCell.setMinHeight(it) }
 
         val innerElement = cell.content.innerElement
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/model/Cell.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/model/Cell.kt
@@ -12,6 +12,7 @@ data class Cell<out T : CellElement>(
     val border: Drawing.Border = Drawing.Border.DEFAULT,
     val stroke: Drawing.Stroke = Drawing.Stroke.DEFAULT,
     val padding: Int = Drawing.Padding.DEFAULT,
+    val minHeight: Float? = null,
     val horizontalAlignment: Alignment.Horizontal = Alignment.Horizontal.DEFAULT,
     val verticalAlignment: Alignment.Vertical = Alignment.Vertical.DEFAULT
 ) : ContainerElement<Element>(content.innerElement)

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/model/dsl/CanvasBuilder.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/model/dsl/CanvasBuilder.kt
@@ -37,7 +37,7 @@ class CanvasBuilder(val safeStroke: Boolean, val page: PageBuilder) : ElementBui
 
     fun lineTo(x: Float, y: Float) {
         commands.add(TurtleCommand.LineTo(x, y))
-        position = position.first + x to position.second + y
+        position = x to y
     }
 
     fun lineInDirection(x: Float, y: Float) {

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/model/dsl/CellBuilder.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/model/dsl/CellBuilder.kt
@@ -9,6 +9,7 @@ class CellBuilder(val colSpan: Int, parent: ElementBuilder?) : PropertiesElement
     var background: RgbColor? = RgbColor.DEFAULT
 
     var padding: Int = Drawing.Padding.DEFAULT
+    var minHeight: Float? = null
 
     var rowSpan: Int = 1
 
@@ -47,6 +48,6 @@ class CellBuilder(val colSpan: Int, parent: ElementBuilder?) : PropertiesElement
     }
 
     fun <T : CellElement> compile(content: T): Cell<T> {
-        return Cell(content, colSpan, rowSpan, background, border, stroke, padding, horizontalAlignment, verticalAlignment)
+        return Cell(content, colSpan, rowSpan, background, border, stroke, padding, minHeight, horizontalAlignment, verticalAlignment)
     }
 }

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/FontUtil.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/pdf/util/FontUtil.kt
@@ -99,6 +99,10 @@ object FontUtil {
                 return listOf(currentPhraseAccu)
             }
 
+            if (currentPhraseAccu.isNotEmpty()) {
+                return accu + listOf(currentPhraseAccu)
+            }
+
             return accu
         }
 

--- a/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFDataBuilder.kt
+++ b/webscrambles/src/main/kotlin/org/worldcubeassociation/tnoodle/server/webscrambles/wcif/WCIFDataBuilder.kt
@@ -153,6 +153,6 @@ object WCIFDataBuilder {
     }
 
     fun compileOutlinePdfBytes(documents: List<Document>, password: String? = null): ByteArray {
-        return ScrambleSheet.RENDERING_ENGINE.renderWithOutline(documents, password)
+        return Document.DEFAULT_ENGINE.renderWithOutline(documents, password)
     }
 }


### PR DESCRIPTION
Because it is the only puzzle where the images are higher than they are wide.