### PR TITLE
Sort competitions by start_date

### DIFF
--- a/tnoodle-ui/src/main/api/wca.api.ts
+++ b/tnoodle-ui/src/main/api/wca.api.ts
@@ -91,6 +91,7 @@ class WcaApi {
         const params = new URLSearchParams({
             managed_by_me: true.toString(),
             start: oneWeekAgo.toISOString(),
+            sort: "start_date",
         });
         return this.wcaApiFetch<Competition[]>(
             `/competitions?${params.toString()}`

--- a/tnoodle-ui/src/main/api/wca.api.ts
+++ b/tnoodle-ui/src/main/api/wca.api.ts
@@ -87,9 +87,13 @@ class WcaApi {
         this.wcaApiFetch<Wcif>(`/competitions/${competitionId}/wcif`);
 
     getUpcomingManageableCompetitions = () => {
-        let oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+        const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+        const params = new URLSearchParams({
+            managed_by_me: true.toString(),
+            start: oneWeekAgo.toISOString(),
+        });
         return this.wcaApiFetch<Competition[]>(
-            `/competitions?managed_by_me=true&start=${oneWeekAgo.toISOString()}`
+            `/competitions?${params.toString()}`
         );
     };
 


### PR DESCRIPTION
Closes #825. Also, tiny refactor to use `URLSearchParams` (same as in https://github.com/thewca/scrambles-matcher/blob/1de93f798ee99aad2ec1d218890091428bf9f532/src/logic/wca-api.js#L5) to make multiple search params cleaner and clearer.