### PR TITLE
WIP Add infra for web scrambles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ gradle.properties
 
 .idea/
 .vscode/
+
+.terraform/

--- a/iac/.terraform.lock.hcl
+++ b/iac/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.31.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:ltxyuBWIy9cq0kIKDJH1jeWJy/y7XJLjS4QrsQK4plA=",
+    "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
+    "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
+    "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
+    "zh:539dd156e3ec608818eb21191697b230117437a58587cbd02ce533202a4dd520",
+    "zh:6a53f4b57ac4eb3479fc0d8b6e301ca3a27efae4c55d9f8bd24071b12a03361c",
+    "zh:6faeb8ff6792ca7af1c025255755ad764667a300291cc10cea0c615479488c87",
+    "zh:7d9423149b323f6d0df5b90c4d9029e5455c670aea2a7eb6fef4684ba7eb2e0b",
+    "zh:8235badd8a5d0993421cacf5ead48fac73d3b5a25c8a68599706a404b1f70730",
+    "zh:860b4f60842b2879c5128b7e386c8b49adeda9287fed12c5cd74861bb659bbcd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b021fceaf9382c8fe3c6eb608c24d01dce3d11ba7e65bb443d51ca9b90e9b237",
+    "zh:b38b0bfc1c69e714e80cf1c9ea06e687ee86aa9f45694be28eb07adcebbe0489",
+    "zh:c972d155f6c01af9690a72adfb99cfc24ef5ef311ca92ce46b9b13c5c153f572",
+    "zh:e0dd29920ec84fdb6026acff44dcc1fb1a24a0caa093fa04cdbc713d384c651d",
+    "zh:e3127ebd2cb0374cd1808f911e6bffe2f4ac4d84317061381242353f3a7bc27d",
+  ]
+}

--- a/iac/alb.tf
+++ b/iac/alb.tf
@@ -1,0 +1,50 @@
+resource "aws_alb" "tnoodle_load_balancer" {
+  name            = "tnoodle-alb"
+  security_groups = [aws_security_group.http_security_group.id]
+  subnets         = [aws_default_subnet.default_az1.id, aws_default_subnet.default_az2.id]
+  idle_timeout    = 300
+
+  tags = {
+    (var.type) = var.type_alb
+  }
+}
+
+resource "aws_alb_listener" "api_lb_listener" {
+  load_balancer_arn = aws_alb.tnoodle_load_balancer.arn
+  port              = var.https_port
+  protocol          = "HTTPS"
+  certificate_arn   = data.aws_acm_certificate.certificate.arn
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.tnoodle_tg.arn
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "tnoodle_tg" {
+  name_prefix = "kctg1"
+  port        = var.tnoodle_port
+  protocol    = "HTTP"
+  vpc_id      = aws_default_vpc.default.id
+  target_type = "ip"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "60"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = "/"
+    unhealthy_threshold = "2"
+  }
+
+  tags = {
+    (var.type) = var.type_tg
+  }
+  depends_on = [aws_alb.tnoodle_load_balancer]
+}

--- a/iac/certificate.tf
+++ b/iac/certificate.tf
@@ -1,0 +1,4 @@
+data "aws_acm_certificate" "certificate" {
+  domain   = "*.worldcubeassociation.org"
+  statuses = ["ISSUED"]
+}

--- a/iac/ecr.tf
+++ b/iac/ecr.tf
@@ -1,0 +1,17 @@
+resource "aws_ecr_repository" "tnoodle" {
+  name = "tnoodle"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    (var.type) = var.type_ecr
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "expire_policy" {
+  repository = aws_ecr_repository.tnoodle.name
+
+  policy = templatefile("./templates/ecr/expire-policy.json", {})
+}

--- a/iac/ecs.tf
+++ b/iac/ecs.tf
@@ -1,0 +1,7 @@
+resource "aws_ecs_cluster" "keycloak_cluster" {
+  name = "tnoodle-cluster"
+
+  tags = {
+    (var.type) = var.type_ecs
+  }
+}

--- a/iac/ecs.tf
+++ b/iac/ecs.tf
@@ -1,6 +1,28 @@
-resource "aws_ecs_cluster" "keycloak_cluster" {
+resource "aws_ecs_cluster" "tnoodle_cluster" {
   name = "tnoodle-cluster"
 
+  tags = {
+    (var.type) = var.type_ecs
+  }
+}
+
+resource "aws_ecs_task_definition" "tnoodle_task_definition" {
+  family                   = "tnoodle-task-definition"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.fargate_cpu
+  memory                   = var.fargate_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = templatefile("./templates/container-definitions/tnoodle.json", {
+    app_image      = aws_ecr_repository.tnoodle.repository_url
+    aws_region     = var.aws_region
+    app_port       = var.tnoodle_port
+    container_name = var.tnoodle_name
+    fargate_cpu    = var.fargate_cpu
+    fargate_memory = var.fargate_memory
+  })
   tags = {
     (var.type) = var.type_ecs
   }

--- a/iac/ecs.tf
+++ b/iac/ecs.tf
@@ -15,7 +15,7 @@ resource "aws_ecs_task_definition" "tnoodle_task_definition" {
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn            = aws_iam_role.ecs_task_execution_role.arn
 
-  container_definitions = templatefile("./templates/container-definitions/tnoodle.json", {
+  container_definitions = templatefile("./templates/container-definitions/tnoodle.json.tpl", {
     app_image      = aws_ecr_repository.tnoodle.repository_url
     aws_region     = var.aws_region
     app_port       = var.tnoodle_port
@@ -23,6 +23,31 @@ resource "aws_ecs_task_definition" "tnoodle_task_definition" {
     fargate_cpu    = var.fargate_cpu
     fargate_memory = var.fargate_memory
   })
+  tags = {
+    (var.type) = var.type_ecs
+  }
+}
+
+resource "aws_ecs_service" "tnoodle_service" {
+  name          = "tnoodle-service"
+  cluster       = aws_ecs_cluster.tnoodle_cluster.id
+  desired_count = 1
+  launch_type   = "FARGATE"
+
+  task_definition = aws_ecs_task_definition.tnoodle_task_definition.arn
+
+  network_configuration {
+    subnets          = [aws_default_subnet.default_az1.id]
+    security_groups  = [aws_security_group.allow_tnoodle_default_port.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.tnoodle_tg.arn
+    container_name   = var.tnoodle_name
+    container_port   = var.tnoodle_port
+  }
+
   tags = {
     (var.type) = var.type_ecs
   }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "s3" {
+    bucket = "NON-EXISTING-BUCKET"
+    key    = "tnoodle-web-scramble"
+    region = "us-west-2"
+  }
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}

--- a/iac/role.tf
+++ b/iac/role.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
           Resource = "*"
         },
         {
-          Action   = ["ecr:GetAuthorizationToken"]
+          Action   = ["ecr:*"]
           Effect   = "Allow"
           Resource = "*"
         }

--- a/iac/role.tf
+++ b/iac/role.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "tnoodle-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+
+  inline_policy {
+    name = "tnoodle-task-execution-role-policy"
+
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Action   = ["logs:*"]
+          Effect   = "Allow"
+          Resource = "*"
+        }
+      ]
+    })
+  }
+}

--- a/iac/role.tf
+++ b/iac/role.tf
@@ -26,6 +26,11 @@ resource "aws_iam_role" "ecs_task_execution_role" {
           Action   = ["logs:*"]
           Effect   = "Allow"
           Resource = "*"
+        },
+        {
+          Action   = ["ecr:GetAuthorizationToken"]
+          Effect   = "Allow"
+          Resource = "*"
         }
       ]
     })

--- a/iac/security-group.tf
+++ b/iac/security-group.tf
@@ -1,0 +1,59 @@
+resource "aws_security_group" "http_security_group" {
+  name        = "http-security-group-tnoodle"
+  description = "Allow HTTP"
+  vpc_id      = aws_default_vpc.default.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = var.http_port
+    to_port     = var.http_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = var.https_port
+    to_port     = var.https_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    (var.type) = var.type_sg
+  }
+}
+
+resource "aws_security_group" "allow_tnoodle_default_port" {
+  name        = "tnoodle-default-port"
+  description = "Allow connection to tnoodle default port"
+  vpc_id      = aws_default_vpc.default.id
+
+  ingress {
+    description = "tnoodle"
+    from_port   = var.tnoodle_port
+    to_port     = var.tnoodle_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    (var.type) = var.type_sg
+  }
+}

--- a/iac/subnet.tf
+++ b/iac/subnet.tf
@@ -1,0 +1,15 @@
+resource "aws_default_subnet" "default_az1" {
+  availability_zone = "us-west-2a"
+
+  tags = {
+    (var.type) = var.type_subnet
+  }
+}
+
+resource "aws_default_subnet" "default_az2" {
+  availability_zone = "us-west-2b"
+
+  tags = {
+    (var.type) = var.type_subnet
+  }
+}

--- a/iac/templates/container-definitions/tnoodle.json
+++ b/iac/templates/container-definitions/tnoodle.json
@@ -1,0 +1,23 @@
+[
+    {
+        "name": "${container_name}",
+        "image": "${app_image}",
+        "cpu": "${fargate_cpu}",
+        "memory": "${fargate_memory}",
+        "networkMode": "awsvpc",
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/ecs/${container_name}",
+                "awslogs-region": "${aws_region}",
+                "awslogs-stream-prefix": "ecs"
+            }
+        },
+        "portMappings": [
+            {
+                "containerPort": "${app_port}",
+                "hostPort": "${app_port}"
+            }
+        ]
+    }
+]

--- a/iac/templates/container-definitions/tnoodle.json.tpl
+++ b/iac/templates/container-definitions/tnoodle.json.tpl
@@ -1,7 +1,7 @@
 [
     {
         "name": "${container_name}",
-        "image": "${app_image}",
+        "image": "${app_image}:latest",
         "cpu": ${fargate_cpu},
         "memory": ${fargate_memory},
         "networkMode": "awsvpc",

--- a/iac/templates/container-definitions/tnoodle.json.tpl
+++ b/iac/templates/container-definitions/tnoodle.json.tpl
@@ -10,7 +10,8 @@
             "options": {
                 "awslogs-group": "/ecs/${container_name}",
                 "awslogs-region": "${aws_region}",
-                "awslogs-stream-prefix": "ecs"
+                "awslogs-stream-prefix": "ecs",
+                "awslogs-create-group": "true"
             }
         },
         "portMappings": [

--- a/iac/templates/container-definitions/tnoodle.json.tpl
+++ b/iac/templates/container-definitions/tnoodle.json.tpl
@@ -2,8 +2,8 @@
     {
         "name": "${container_name}",
         "image": "${app_image}",
-        "cpu": "${fargate_cpu}",
-        "memory": "${fargate_memory}",
+        "cpu": ${fargate_cpu},
+        "memory": ${fargate_memory},
         "networkMode": "awsvpc",
         "logConfiguration": {
             "logDriver": "awslogs",
@@ -15,8 +15,8 @@
         },
         "portMappings": [
             {
-                "containerPort": "${app_port}",
-                "hostPort": "${app_port}"
+                "containerPort": ${app_port},
+                "hostPort": ${app_port}
             }
         ]
     }

--- a/iac/templates/ecr/expire-policy.json
+++ b/iac/templates/ecr/expire-policy.json
@@ -1,0 +1,16 @@
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Keep last 2 images",
+            "selection": {
+                "tagStatus": "any",
+                "countType": "imageCountMoreThan",
+                "countNumber": 2
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}

--- a/iac/variable.tf
+++ b/iac/variable.tf
@@ -5,3 +5,27 @@ variable "type" {
 variable "type_ecs" {
   default = "ECS"
 }
+
+variable "aws_region" {
+  default = "us-west-2"
+}
+
+variable "tnoodle_name" {
+  default = "tnoodle"
+}
+
+variable "type_ecr" {
+  default = "ECR"
+}
+
+variable "tnoodle_port" {
+  default = "2014"
+}
+
+variable "fargate_cpu" {
+  default = "1024" # 1 vCPU
+}
+
+variable "fargate_memory" {
+  default = "2048" # 2 GB
+}

--- a/iac/variable.tf
+++ b/iac/variable.tf
@@ -1,0 +1,7 @@
+variable "type" {
+  default = "Type"
+}
+
+variable "type_ecs" {
+  default = "ECS"
+}

--- a/iac/variable.tf
+++ b/iac/variable.tf
@@ -29,3 +29,27 @@ variable "fargate_cpu" {
 variable "fargate_memory" {
   default = "2048" # 2 GB
 }
+
+variable "type_subnet" {
+  default = "SUBNET"
+}
+
+variable "type_sg" {
+  default = "SECURITY-GROUP"
+}
+
+variable "type_tg" {
+  default = "TARGET-GROUP"
+}
+
+variable "type_alb" {
+  default = "LOAD-BALANCER"
+}
+
+variable "http_port" {
+  default = "80"
+}
+
+variable "https_port" {
+  default = "443"
+}

--- a/iac/vpc.tf
+++ b/iac/vpc.tf
@@ -1,0 +1,5 @@
+resource "aws_default_vpc" "default" {
+  tags = {
+    Name = "Default VPC"
+  }
+}


### PR DESCRIPTION
Quick fix because os specific is starting to be critical.

This introduces terraform so we can run tnoodle with docker in AWS.