### PR TITLE
Add option to sort passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ gradle.properties
 
 .idea/
 .vscode/
+.DS_Store

--- a/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ActivityPasscode.kt
+++ b/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ActivityPasscode.kt
@@ -1,0 +1,10 @@
+package org.worldcubeassociation.tnoodle.server.zip
+
+import org.worldcubeassociation.tnoodle.server.wcif.model.ActivityCode
+
+class ActivityPasscode(
+    val passcode: String,
+    var activityCode: ActivityCode? = null,
+    var title: String? = ""
+) {
+}

--- a/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ComputerDisplayZip.kt
+++ b/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ComputerDisplayZip.kt
@@ -22,7 +22,7 @@ data class ComputerDisplayZip(
         return zipArchive {
             for ((uniqueTitle, scrambleDoc) in scrambleSets) {
                 val passcode = passcodes.getValue(uniqueTitle)
-                passcode.activityCode = scrambleDoc
+                passcode.activityCode = scrambleDoc.activityCode
                 passcode.title = uniqueTitle
 
                 val pdfBytes = scrambleDoc.render(passcode.passcode)

--- a/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ComputerDisplayZip.kt
+++ b/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ComputerDisplayZip.kt
@@ -1,12 +1,15 @@
 package org.worldcubeassociation.tnoodle.server.zip
 
 import org.worldcubeassociation.tnoodle.server.pdf.ScrambleSheet
-import org.worldcubeassociation.tnoodle.server.zip.util.StringUtil.randomPasscode
 import org.worldcubeassociation.tnoodle.server.zip.model.ZipArchive
 import org.worldcubeassociation.tnoodle.server.zip.model.dsl.zipArchive
+import org.worldcubeassociation.tnoodle.server.zip.util.StringUtil.randomPasscode
 
-data class ComputerDisplayZip(val scrambleSets: Map<String, ScrambleSheet>, val competitionTitle: String) {
-    val passcodes = scrambleSets.mapValues { randomPasscode() }
+data class ComputerDisplayZip(
+    val scrambleSets: Map<String, ScrambleSheet>,
+    val competitionTitle: String
+) {
+    val passcodes = scrambleSets.mapValues { ActivityPasscode(randomPasscode()) }
 
     /**
      * Computer display zip
@@ -19,7 +22,10 @@ data class ComputerDisplayZip(val scrambleSets: Map<String, ScrambleSheet>, val 
         return zipArchive {
             for ((uniqueTitle, scrambleDoc) in scrambleSets) {
                 val passcode = passcodes.getValue(uniqueTitle)
-                val pdfBytes = scrambleDoc.render(passcode)
+                passcode.activityCode = scrambleDoc
+                passcode.title = uniqueTitle
+
+                val pdfBytes = scrambleDoc.render(passcode.passcode)
 
                 file("$uniqueTitle.pdf", pdfBytes)
             }

--- a/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ScrambleZip.kt
+++ b/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ScrambleZip.kt
@@ -1,12 +1,12 @@
 package org.worldcubeassociation.tnoodle.server.zip
 
 import org.worldcubeassociation.tnoodle.server.pdf.ScrambleSheet
-import org.worldcubeassociation.tnoodle.server.zip.util.StringUtil.toFileSafeString
 import org.worldcubeassociation.tnoodle.server.wcif.model.Competition
 import org.worldcubeassociation.tnoodle.server.zip.model.ZipArchive
 import org.worldcubeassociation.tnoodle.server.zip.model.dsl.zipArchive
+import org.worldcubeassociation.tnoodle.server.zip.util.StringUtil.toFileSafeString
 import java.time.LocalDateTime
-import java.util.Locale
+import java.util.*
 
 data class ScrambleZip(
     val wcif: Competition,
@@ -16,23 +16,42 @@ data class ScrambleZip(
 ) {
     private val globalTitle get() = wcif.shortName
 
-    fun assemble(generationDate: LocalDateTime, versionTag: String, pdfPassword: String?, generationUrl: String?): ZipArchive {
+    fun assemble(
+        generationDate: LocalDateTime,
+        versionTag: String,
+        pdfPassword: String?,
+        generationUrl: String?
+    ): ZipArchive {
         val computerDisplayZip = ComputerDisplayZip(namedSheets, globalTitle)
         val computerDisplayZipBytes = computerDisplayZip.assemble()
 
         val interchangeFolder = InterchangeFolder(wcif, namedSheets, globalTitle)
-        val interchangeFolderNode = interchangeFolder.assemble(generationDate, versionTag, generationUrl)
+        val interchangeFolderNode =
+            interchangeFolder.assemble(generationDate, versionTag, generationUrl)
 
         val printingFolder = PrintingFolder(wcif, namedSheets, fmcTranslations, watermark)
         val printingFolderNode = printingFolder.assemble(pdfPassword)
 
         val passcodeList = computerDisplayZip.passcodes.entries
-            .joinToString("\r\n") { "${it.key}: ${it.value}" }
+            .joinToString("\r\n") { "${it.key}: ${it.value.passcode}" }
 
         val passcodeListingTxt = this::class.java.getResourceAsStream(TXT_PASSCODE_TEMPLATE)
             .bufferedReader().readText()
             .replace("%%GLOBAL_TITLE%%", globalTitle)
             .replace("%%PASSCODES%%", passcodeList)
+
+        val passcodesOrdered = wcif.schedule.activitiesWithLocalStartTimes.entries
+            .sortedBy { it.value }
+            .map { computerDisplayZip.passcodes.entries.find { e -> e.value.activityCode?.activityCodeString == it.key.activityCode.activityCodeString }?.value }
+            .distinct()
+        val orderedPasscodeList = passcodesOrdered
+            .filterNotNull()
+            .joinToString("\r\n") { "${it.title}: ${it.passcode}" }
+
+        val orderedPasscodeListingTxt = this::class.java.getResourceAsStream(TXT_PASSCODE_TEMPLATE)
+            .bufferedReader().readText()
+            .replace("%%GLOBAL_TITLE%%", globalTitle)
+            .replace("%%PASSCODES%%", orderedPasscodeList)
 
         val filesafeGlobalTitle = globalTitle.toFileSafeString()
 
@@ -40,8 +59,18 @@ data class ScrambleZip(
             folder(printingFolderNode)
             folder(interchangeFolderNode)
 
-            file("$filesafeGlobalTitle - Computer Display PDFs.zip", computerDisplayZipBytes.compress())
-            file("$filesafeGlobalTitle - Computer Display PDF Passcodes - SECRET.txt", passcodeListingTxt)
+            file(
+                "$filesafeGlobalTitle - Computer Display PDFs.zip",
+                computerDisplayZipBytes.compress()
+            )
+            file(
+                "$filesafeGlobalTitle - Computer Display PDF Passcodes - SECRET.txt",
+                passcodeListingTxt
+            )
+            file(
+                "$filesafeGlobalTitle - Ordered Computer Display PDF Passcodes - SECRET.txt",
+                orderedPasscodeListingTxt
+            )
         }
     }
 

--- a/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ScrambleZip.kt
+++ b/server/src/main/kotlin/org/worldcubeassociation/tnoodle/server/zip/ScrambleZip.kt
@@ -32,14 +32,19 @@ data class ScrambleZip(
         val printingFolder = PrintingFolder(wcif, namedSheets, fmcTranslations, watermark)
         val printingFolderNode = printingFolder.assemble(pdfPassword)
 
-        val passcodeList = computerDisplayZip.passcodes.entries
-            .joinToString("\r\n") { "${it.key}: ${it.value.passcode}" }
 
         val resourceTemplate = this::class.java.getResourceAsStream(TXT_PASSCODE_TEMPLATE)
             .bufferedReader().readText()
             .replace("%%GLOBAL_TITLE%%", globalTitle)
 
+        val passcodeList = computerDisplayZip.passcodes.entries
+            .joinToString("\r\n") { "${it.key}: ${it.value.passcode}" }
+
         val passcodeListingTxt = resourceTemplate.replace("%%PASSCODES%%", passcodeList)
+
+        // This sorts passwords so delegates can linearly read them.
+        // This is inspired by https://github.com/simonkellly/scramble-organizer
+        // which may become deprecated after this so we are giving credit here.
 
         val passcodesOrdered = wcif.schedule.activitiesWithLocalStartTimes.entries
             .sortedBy { it.value }
@@ -55,6 +60,7 @@ data class ScrambleZip(
                 }?.value
             }
             .distinct()
+
         val orderedPasscodeList = passcodesOrdered
             .filterNotNull()
             .joinToString("\r\n") { "${it.title}: ${it.passcode}" }


### PR DESCRIPTION
This includes a file that matches PDFs passwords to schedule. We need to remove the amount of tools delegates use, some delegates are using https://github.com/simonkellly/scramble-organizer for this (and simonkellly was the inspiration)

This is a schedule

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/7e8e09c9-0b05-463c-ac3d-6d4006946ce9" />

Regular passcodes

<img width="903" alt="image" src="https://github.com/user-attachments/assets/a4b2da2d-a3c0-4be3-8cfb-493423858d8f" />

Sorted passcodes

<img width="903" alt="image" src="https://github.com/user-attachments/assets/51d0bbbd-a40e-4787-be53-d838c0f354fe" />

This file is optionally added

<img width="906" alt="image" src="https://github.com/user-attachments/assets/cd983b57-4812-444a-83a5-613bda5c481a" />
